### PR TITLE
issue #76: Fixed MosaicInfoDTO fields with new cow DTO content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.10.3-4",
+  "version": "0.10.3-5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.10.3-4",
+  "version": "0.10.3-5",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",

--- a/src/infrastructure/MosaicHttp.ts
+++ b/src/infrastructure/MosaicHttp.ts
@@ -61,14 +61,12 @@ export class MosaicHttp extends Http implements MosaicRepository {
             mergeMap((networkType) => observableFrom(
                 this.mosaicRoutesApi.getMosaic(mosaicId.toHex())).pipe(map((mosaicInfoDTO) => {
                 return new MosaicInfo(
-                    mosaicInfoDTO.meta.active,
-                    mosaicInfoDTO.meta.index,
                     mosaicInfoDTO.meta.id,
                     new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
-                    new UInt64(mosaicInfoDTO.mosaic.nonce),
                     new UInt64(mosaicInfoDTO.mosaic.supply),
                     new UInt64(mosaicInfoDTO.mosaic.height),
                     PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
+                    mosaicInfoDTO.mosaic.revision,
                     new MosaicProperties(
                         new UInt64(mosaicInfoDTO.mosaic.properties[0]),
                         (new UInt64(mosaicInfoDTO.mosaic.properties[1])).compact(),
@@ -93,14 +91,12 @@ export class MosaicHttp extends Http implements MosaicRepository {
                 this.mosaicRoutesApi.getMosaics(mosaicIdsBody)).pipe(map((mosaicInfosDTO) => {
                 return mosaicInfosDTO.map((mosaicInfoDTO) => {
                     return new MosaicInfo(
-                        mosaicInfoDTO.meta.active,
-                        mosaicInfoDTO.meta.index,
                         mosaicInfoDTO.meta.id,
                         new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
-                        new UInt64(mosaicInfoDTO.mosaic.nonce),
                         new UInt64(mosaicInfoDTO.mosaic.supply),
                         new UInt64(mosaicInfoDTO.mosaic.height),
                         PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
+                        mosaicInfoDTO.mosaic.revision,
                         new MosaicProperties(
                             new UInt64(mosaicInfoDTO.mosaic.properties[0]),
                             (new UInt64(mosaicInfoDTO.mosaic.properties[1])).compact(),

--- a/src/model/mosaic/MosaicInfo.ts
+++ b/src/model/mosaic/MosaicInfo.ts
@@ -36,14 +36,6 @@ export class MosaicInfo {
      * @param levy
      */
     constructor(/**
-                 * Mosaic is active.
-                 */
-                public readonly active: boolean,
-                /**
-                 * The mosaic index.
-                 */
-                public readonly index: number,
-                /**
                  * The meta data id.
                  */
                 public readonly metaId: string,
@@ -51,10 +43,6 @@ export class MosaicInfo {
                  * The mosaic id.
                  */
                 public readonly mosaicId: MosaicId,
-                /**
-                 * The mosaic nonce.
-                 */
-                public readonly nonce: UInt64,
                 /**
                  * The mosaic supply.
                  */
@@ -67,6 +55,10 @@ export class MosaicInfo {
                  * The public key of the mosaic creator.
                  */
                 public readonly owner: PublicAccount,
+                /**
+                 * The mosaic revision
+                 */
+                public readonly revision: number,
                 /**
                  * The mosaic properties.
                  */

--- a/test/model/mosaic/MosaicAmountView.spec.ts
+++ b/test/model/mosaic/MosaicAmountView.spec.ts
@@ -29,16 +29,21 @@ describe('MosaicAmountView', () => {
     let mosaicInfo: MosaicInfo;
 
     before(() => {
-        mosaicInfo = new MosaicInfo(true, 0, '59FDA0733F17CF0001772CBC', new MosaicId([3294802500, 2243684972]), 
-            new UInt64([1, 0]), new UInt64([3403414400, 2095475]), new UInt64([1, 0]),
+        mosaicInfo = new MosaicInfo(
+            '59FDA0733F17CF0001772CBC',
+            new MosaicId([3294802500, 2243684972]), // mosaicId
+            new UInt64([3403414400, 2095475]), // supply
+            new UInt64([1, 0]), // height
             PublicAccount.createFromPublicKey('B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF', NetworkType.MIJIN_TEST),
+            1, // revision
             MosaicProperties.create({
                 supplyMutable: true,
                 transferable: true,
                 levyMutable: true,
                 divisibility: 3,
                 duration: UInt64.fromUint(1000),
-            }), {});
+            }),
+            {});
     });
 
     it('should createComplete a Mosaic Amount View', () => {

--- a/test/model/mosaic/MosaicInfo.spec.ts
+++ b/test/model/mosaic/MosaicInfo.spec.ts
@@ -27,32 +27,22 @@ import {NamespaceId} from '../../../src/model/namespace/NamespaceId';
 describe('MosaicInfo', () => {
     const mosaicInfoDTO = {
         meta: {
-            active: true,
             id: '59FDA0733F17CF0001772CBC',
-            index: 0,
         },
         mosaic: {
-            height: new UInt64([1, 0]),
-            levy: {},
             mosaicId: new MosaicId([3646934825, 3576016193]),
-            nonce: new UInt64([1, 0]),
-            owner: PublicAccount.createFromPublicKey('B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF',
-                NetworkType.MIJIN_TEST),
-            properties: [
-                new UInt64([
-                    6,
-                    0,
-                ]),
-                new UInt64([
-                    3,
-                    0,
-                ]),
-                new UInt64([
-                    1000,
-                    0,
-                ]),
-            ],
             supply: new UInt64([3403414400, 2095475]),
+            height: new UInt64([1, 0]),
+            owner: PublicAccount.createFromPublicKey(
+                'B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF',
+                NetworkType.MIJIN_TEST),
+            revision: 1,
+            properties: [
+                new UInt64([6, 0]), // divisibility
+                new UInt64([3, 0]), // flags
+                new UInt64([1000, 0]), // duration
+            ],
+            levy: {},
         },
     };
 
@@ -62,14 +52,12 @@ describe('MosaicInfo', () => {
 
     it('should createComplete an MosaicInfo object', () => {
         const mosaicInfo = new MosaicInfo(
-            mosaicInfoDTO.meta.active,
-            mosaicInfoDTO.meta.index,
             mosaicInfoDTO.meta.id,
             mosaicInfoDTO.mosaic.mosaicId,
-            mosaicInfoDTO.mosaic.nonce,
             mosaicInfoDTO.mosaic.supply,
             mosaicInfoDTO.mosaic.height,
             mosaicInfoDTO.mosaic.owner,
+            mosaicInfoDTO.mosaic.revision,
             new MosaicProperties(
                 mosaicInfoDTO.mosaic.properties[0],
                 mosaicInfoDTO.mosaic.properties[1].compact(),
@@ -78,14 +66,12 @@ describe('MosaicInfo', () => {
             mosaicInfoDTO.mosaic.levy,
         );
 
-        expect(mosaicInfo.active).to.be.equal(mosaicInfoDTO.meta.active);
-        expect(mosaicInfo.index).to.be.equal(mosaicInfoDTO.meta.index);
         expect(mosaicInfo.metaId).to.be.equal(mosaicInfoDTO.meta.id);
         deepEqual(mosaicInfo.mosaicId, mosaicInfoDTO.mosaic.mosaicId);
-        deepEqual(mosaicInfo.nonce, mosaicInfoDTO.mosaic.nonce);
         deepEqual(mosaicInfo.supply, mosaicInfoDTO.mosaic.supply);
         deepEqual(mosaicInfo.height, mosaicInfoDTO.mosaic.height);
         expect(mosaicInfo.owner).to.be.equal(mosaicInfoDTO.mosaic.owner);
+        deepEqual(mosaicInfo.revision, mosaicInfoDTO.mosaic.revision);
 
         expect(mosaicInfo.divisibility).to.be.equal(mosaicInfoDTO.mosaic.properties[1].lower);
         deepEqual(mosaicInfo.duration, mosaicInfoDTO.mosaic.properties[2]);
@@ -95,14 +81,12 @@ describe('MosaicInfo', () => {
     describe('isSupplyMutable', () => {
         it('should return true when it\'s mutable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: true,
                     transferable: false,
@@ -118,14 +102,12 @@ describe('MosaicInfo', () => {
 
         it('should return false when it\'s immutable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: false,
                     transferable: false,
@@ -142,14 +124,12 @@ describe('MosaicInfo', () => {
     describe('isTransferable', () => {
         it('should return true when it\'s transferable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: false,
                     transferable: true,
@@ -164,14 +144,12 @@ describe('MosaicInfo', () => {
 
         it('should return false when it\'s not transferable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: false,
                     transferable: false,
@@ -188,14 +166,12 @@ describe('MosaicInfo', () => {
     describe('isLevyMutable', () => {
         it('should return true when it\'s mutable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: true,
                     transferable: false,
@@ -210,14 +186,12 @@ describe('MosaicInfo', () => {
 
         it('should return false when it\'s immutable', () => {
             const mosaicInfo = new MosaicInfo(
-                mosaicInfoDTO.meta.active,
-                mosaicInfoDTO.meta.index,
                 mosaicInfoDTO.meta.id,
                 mosaicInfoDTO.mosaic.mosaicId,
-                mosaicInfoDTO.mosaic.nonce,
                 mosaicInfoDTO.mosaic.supply,
                 mosaicInfoDTO.mosaic.height,
                 mosaicInfoDTO.mosaic.owner,
+                mosaicInfoDTO.mosaic.revision,
                 MosaicProperties.create({
                     supplyMutable: false,
                     transferable: false,

--- a/test/model/mosaic/MosaicView.spec.ts
+++ b/test/model/mosaic/MosaicView.spec.ts
@@ -29,9 +29,13 @@ describe('MosaicView', () => {
     let mosaicInfo: MosaicInfo;
 
     before(() => {
-        mosaicInfo = new MosaicInfo(true, 0, '59FDA0733F17CF0001772CBC', new MosaicId([3294802500, 2243684972]),
-            new UInt64([1, 0]), new UInt64([3403414400, 2095475]), new UInt64([1, 0]),
+        mosaicInfo = new MosaicInfo(
+            '59FDA0733F17CF0001772CBC',
+            new MosaicId([3294802500, 2243684972]),
+            new UInt64([3403414400, 2095475]), // supply
+            new UInt64([1, 0]), // height
             PublicAccount.createFromPublicKey('B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF', NetworkType.MIJIN_TEST),
+            1, // revision
             MosaicProperties.create({
                 supplyMutable: true,
                 transferable: true,


### PR DESCRIPTION
Fixed MosaicInfoDTO in response of issue #76 .

https://github.com/nemtech/nem2-sdk-typescript-javascript/issues/76

Fields updated in cow network upgrade when calling `/mosaic/{mosaicId}` endpoint, in MosaicInfoDTO: 

- Removed field `meta.active`
- Removed field `meta.index` 
- Removed field `mosaic.nonce`
- Added field `mosaic.revision`
