### PR TITLE
#55 : Added Alias capability for TransferTransaction.recipient field …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1213,20 +1213,20 @@
       "integrity": "sha512-bAdJv7fBLhWC+/Bls0Oza+mvTaNQtP+1RyhhhvD95pgUJz6XM5IzgmxOkItJ9tkoCiplvAnXI1tNmmUD/eScyA=="
     },
     "nem2-library": {
-      "version": "0.9.11",
-      "resolved": "https://registry.npmjs.org/nem2-library/-/nem2-library-0.9.11.tgz",
-      "integrity": "sha512-FoTXkGQfx3gKd4w37zU+j9INdp9I/9qN8P7GEicuss3ikcGXxIwXv0rokME6x7FZUW0m17C3CkV0stAPZ1nk3w==",
+      "version": "0.9.12",
+      "resolved": "https://registry.npmjs.org/nem2-library/-/nem2-library-0.9.12.tgz",
+      "integrity": "sha512-yXNlR9psgPTiPMOFJFAEpuw8zSUdg5Z8iue+8JaTIKZBm/xTFz1jnFvhpxPMoowa5KcCpcLHsOu1mEQDGZ34ow==",
       "requires": {
-        "bufferutil": "3.0.5",
+        "bufferutil": "^3.0.5",
         "crypto-browserify": "3.12.0",
-        "crypto-js": "3.1.9-1",
-        "flatbuffers": "1.10.2",
-        "js-sha3": "0.6.1",
-        "lodash": "4.17.11",
-        "ripemd160": "2.0.2",
-        "superagent": "3.8.3",
-        "utf-8-validate": "4.0.2",
-        "ws": "5.2.0"
+        "crypto-js": "^3.1.9-1",
+        "flatbuffers": "^1.7.0",
+        "js-sha3": "^0.6.1",
+        "lodash": "^4.17.10",
+        "ripemd160": "^2.0.1",
+        "superagent": "^3.8.3",
+        "utf-8-validate": "^4.0.2",
+        "ws": "^5.2.0"
       },
       "dependencies": {
         "lodash": {

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "@types/crypto-js": "^3.1.43",
     "crypto-js": "^3.1.9-1",
     "js-joda": "^1.6.2",
-    "nem2-library": "^0.9.11",
+    "nem2-library": "^0.9.12",
     "request": "^2.83.0",
     "request-promise-native": "^1.0.5",
     "rxjs": "^6.2.1",

--- a/src/infrastructure/Listener.ts
+++ b/src/infrastructure/Listener.ts
@@ -20,6 +20,7 @@ import * as WebSocket from 'ws';
 import {Address} from '../model/account/Address';
 import {PublicAccount} from '../model/account/PublicAccount';
 import {BlockInfo} from '../model/blockchain/BlockInfo';
+import {NamespaceId} from '../model/namespace/NamespaceId';
 import {AggregateTransaction} from '../model/transaction/AggregateTransaction';
 import {AggregateTransactionCosignature} from '../model/transaction/AggregateTransactionCosignature';
 import {CosignatureSignedTransaction} from '../model/transaction/CosignatureSignedTransaction';
@@ -375,8 +376,16 @@ export class Listener {
      * @param address
      * @returns {boolean}
      */
-    private transactionHasSignerOrReceptor(transaction: Transaction, address: Address): boolean {
-        return transaction.signer!.address.equals(address) ||
-            (transaction instanceof TransferTransaction && transaction.recipient.equals(address));
+    private transactionHasSignerOrReceptor(transaction: Transaction, address: Address | NamespaceId): boolean {
+
+        if (address instanceof NamespaceId) {
+            return transaction instanceof TransferTransaction
+                && (transaction.recipient as NamespaceId).equals(address);
+        }
+
+        return transaction.signer!.address.equals(address) || (
+               transaction instanceof TransferTransaction
+            && (transaction.recipient as Address).equals(address)
+        );
     }
 }

--- a/src/model/namespace/MosaicAlias.ts
+++ b/src/model/namespace/MosaicAlias.ts
@@ -51,4 +51,12 @@ export class MosaicAlias implements Alias {
         }
         return false;
     }
+
+    /**
+     * Get string value of mosaicId
+     * @returns {string}
+     */
+    public toHex(): string {
+        return this.mosaicId.toHex();
+    }
 }

--- a/src/model/transaction/AddressAliasTransaction.ts
+++ b/src/model/transaction/AddressAliasTransaction.ts
@@ -48,7 +48,7 @@ export class AddressAliasTransaction extends Transaction {
                          address: Address,
                          networkType: NetworkType): AddressAliasTransaction {
         return new AddressAliasTransaction(networkType,
-            TransactionVersion.MOSAIC_ALIAS,
+            TransactionVersion.ADDRESS_ALIAS,
             deadline,
             new UInt64([0, 0]),
             actionType,
@@ -88,7 +88,7 @@ export class AddressAliasTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.MOSAIC_ALIAS, networkType, version, deadline, fee, signature, signer, transactionInfo);
+        super(TransactionType.ADDRESS_ALIAS, networkType, version, deadline, fee, signature, signer, transactionInfo);
     }
 
     /**

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -94,7 +94,7 @@ export class TransferTransaction extends Transaction {
      * @internal
      * @returns {string}
      */
-    protected recipientToString(): string {
+    public recipientToString(): string {
         if (this.recipient instanceof NamespaceId) {
             // namespaceId available, return hexadecimal notation
             return (this.recipient as NamespaceId).toHex();

--- a/src/model/transaction/TransferTransaction.ts
+++ b/src/model/transaction/TransferTransaction.ts
@@ -19,6 +19,7 @@ import { Address } from '../account/Address';
 import { PublicAccount } from '../account/PublicAccount';
 import { NetworkType } from '../blockchain/NetworkType';
 import { Mosaic } from '../mosaic/Mosaic';
+import { NamespaceId } from '../namespace/NamespaceId';
 import { UInt64 } from '../UInt64';
 import { Deadline } from './Deadline';
 import { Message } from './Message';
@@ -41,7 +42,7 @@ export class TransferTransaction extends Transaction {
      * @returns {TransferTransaction}
      */
     public static create(deadline: Deadline,
-                         recipient: Address,
+                         recipient: Address | NamespaceId,
                          mosaics: Mosaic[],
                          message: Message,
                          networkType: NetworkType): TransferTransaction {
@@ -73,7 +74,7 @@ export class TransferTransaction extends Transaction {
                 /**
                  * The address of the recipient.
                  */
-                public readonly recipient: Address,
+                public readonly recipient: Address | NamespaceId,
                 /**
                  * The array of Mosaic objects.
                  */
@@ -89,6 +90,21 @@ export class TransferTransaction extends Transaction {
     }
 
     /**
+     * Return the string notation for the set recipient
+     * @internal
+     * @returns {string}
+     */
+    protected recipientToString(): string {
+        if (this.recipient instanceof NamespaceId) {
+            // namespaceId available, return hexadecimal notation
+            return (this.recipient as NamespaceId).toHex();
+        }
+
+        // address available
+        return (this.recipient as Address).plain();
+    }
+
+    /**
      * @internal
      * @returns {VerifiableTransaction}
      */
@@ -97,7 +113,7 @@ export class TransferTransaction extends Transaction {
             .addDeadline(this.deadline.toDTO())
             .addFee(this.fee.toDTO())
             .addVersion(this.versionToDTO())
-            .addRecipient(this.recipient.plain())
+            .addRecipient(this.recipientToString())
             .addMosaics(this.mosaics.map((mosaic) => mosaic.toDTO()))
             .addMessage(this.message)
             .build();

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -106,4 +106,48 @@ describe('TransferTransaction', () => {
         )).to.be.equal('9151776168D24257D8000000000000000000000000000000000D000100746573742D6D657373616765' +
             '44B262C46CEABB8500E1F50500000000');
     });
+
+    it('should format TransferTransaction payload with 25 bytes binary address', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
+            [
+                NetworkCurrencyMosaic.createRelative(100),
+            ],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+
+        // test recipientToString with Address recipient
+        expect(transferTransaction.recipientToString()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+
+        const signedTransaction = transferTransaction.signWith(account);
+
+        expect(signedTransaction.payload.substring(
+            240,
+            290,
+        )).to.be.equal('9050B9837EFAB4BBE8A4B9BB32D812F9885C00D8FC1650E142');
+    });
+
+    it('should format TransferTransaction payload with 8 bytes binary namespaceId', () => {
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            new NamespaceId('nem.owner'),
+            [
+                NetworkCurrencyMosaic.createRelative(100),
+            ],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+
+        // test recipientToString with NamespaceId recipient
+        expect(transferTransaction.recipientToString()).to.be.equal('d85742d268617751');
+
+        const signedTransaction = transferTransaction.signWith(account);
+
+        expect(signedTransaction.payload.substring(
+            240,
+            290,
+        )).to.be.equal('9151776168D24257D800000000000000000000000000000000');
+    });
 });

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -19,6 +19,7 @@ import { Account } from '../../../src/model/account/Account';
 import { Address } from '../../../src/model/account/Address';
 import { NetworkType } from '../../../src/model/blockchain/NetworkType';
 import { NetworkCurrencyMosaic } from '../../../src/model/mosaic/NetworkCurrencyMosaic';
+import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
 import { Deadline } from '../../../src/model/transaction/Deadline';
 import { PlainMessage } from '../../../src/model/transaction/PlainMessage';
 import { TransferTransaction } from '../../../src/model/transaction/TransferTransaction';
@@ -42,7 +43,8 @@ describe('TransferTransaction', () => {
 
         expect(transferTransaction.message.payload).to.be.equal('test-message');
         expect(transferTransaction.mosaics.length).to.be.equal(0);
-        expect(transferTransaction.recipient.plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        expect(transferTransaction.recipient).to.be.instanceof(Address);
+        expect((transferTransaction.recipient as Address).plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
 
         const signedTransaction = transferTransaction.signWith(account);
 
@@ -65,7 +67,8 @@ describe('TransferTransaction', () => {
 
         expect(transferTransaction.message.payload).to.be.equal('test-message');
         expect(transferTransaction.mosaics.length).to.be.equal(1);
-        expect(transferTransaction.recipient.plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
+        expect(transferTransaction.recipient).to.be.instanceof(Address);
+        expect((transferTransaction.recipient as Address).plain()).to.be.equal('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
 
         const signedTransaction = transferTransaction.signWith(account);
 
@@ -74,6 +77,33 @@ describe('TransferTransaction', () => {
             signedTransaction.payload.length,
         )).to.be.equal(
             '9050B9837EFAB4BBE8A4B9BB32D812F9885C00D8FC1650E1420D000100746573742D6D657373616765' +
+            '44B262C46CEABB8500E1F50500000000');
+    });
+
+    it('should createComplete an TransferTransaction object with NamespaceId recipient', () => {
+        const addressAlias = new NamespaceId('nem.owner');
+        const transferTransaction = TransferTransaction.create(
+            Deadline.create(),
+            addressAlias,
+            [
+                NetworkCurrencyMosaic.createRelative(100),
+            ],
+            PlainMessage.create('test-message'),
+            NetworkType.MIJIN_TEST,
+        );
+
+        expect(transferTransaction.message.payload).to.be.equal('test-message');
+        expect(transferTransaction.mosaics.length).to.be.equal(1);
+        expect(transferTransaction.recipient).to.be.instanceof(NamespaceId);
+        expect(transferTransaction.recipient).to.be.equal(addressAlias);
+        expect((transferTransaction.recipient as NamespaceId).toHex()).to.be.equal(addressAlias.toHex());
+
+        const signedTransaction = transferTransaction.signWith(account);
+
+        expect(signedTransaction.payload.substring(
+            240,
+            signedTransaction.payload.length,
+        )).to.be.equal('9151776168D24257D8000000000000000000000000000000000D000100746573742D6D657373616765' +
             '44B262C46CEABB8500E1F50500000000');
     });
 });


### PR DESCRIPTION
Implementation proposal for issue #55  : Added Alias capability for TransferTransaction.recipient field with `Address | NamespaceId` type.

- Includes an update of `Listener` class to detect `signer` and `recipient` fields.
- Includes an update of `TransferTransaction` class to add `recipientToString()` helper.