### PR TITLE
issue #82: Fixed MosaicService to pass single MosaicInfo object instead of array

### DIFF
--- a/e2e/service/MosaicService.spec.ts
+++ b/e2e/service/MosaicService.spec.ts
@@ -1,7 +1,6 @@
 import { map, mergeMap, toArray } from 'rxjs/operators';
 import { AccountHttp } from '../../src/infrastructure/AccountHttp';
 import { MosaicHttp } from '../../src/infrastructure/MosaicHttp';
-import { NamespaceHttp } from '../../src/infrastructure/NamespaceHttp';
 import { Address } from '../../src/model/account/Address';
 import { MosaicService } from '../../src/service/MosaicService';
 import { APIUrl } from '../conf/conf.spec';
@@ -12,7 +11,6 @@ describe('MosaicService', () => {
         const mosaicService = new MosaicService(
             new AccountHttp(APIUrl),
             new MosaicHttp(APIUrl),
-            new NamespaceHttp(APIUrl),
         );
 
         const address = Address.createFromRawAddress('SCO2JY-N6OJSM-CJPPVS-Z3OX7P-TWPQEJ-GZTI6W-GLKK');

--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -68,7 +68,7 @@ export class MosaicService {
             mergeMap((mosaic: Mosaic) => this.mosaicsView([mosaic.id]).pipe(
                 filter((_) => _.length !== 0),
                 map<MosaicView[], MosaicAmountView>((mosaicViews) => {
-                    return new MosaicAmountView(mosaicViews[0].mosaicInfo, mosaic.amount);
+                    return new MosaicAmountView(mosaicViews[0].mosaicInfo[0], mosaic.amount);
                 }),
             toArray())));
     }

--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -35,11 +35,9 @@ export class MosaicService {
      * Constructor
      * @param accountHttp
      * @param mosaicHttp
-     * @param namespaceHttp
      */
     constructor(private readonly accountHttp: AccountHttp,
-                private readonly mosaicHttp: MosaicHttp,
-                private readonly namespaceHttp: NamespaceHttp) {
+                private readonly mosaicHttp: MosaicHttp) {
 
     }
 

--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -49,6 +49,7 @@ export class MosaicService {
     mosaicsView(mosaicIds: MosaicId[]): Observable<MosaicView[]> {
         return observableOf(mosaicIds).pipe(
             mergeMap((_) => this.mosaicHttp.getMosaics(mosaicIds).pipe(
+                mergeMap((_) => _),
                 map((mosaicInfo: MosaicInfo) => {
                     return new MosaicView(mosaicInfo);
                 }),
@@ -66,7 +67,7 @@ export class MosaicService {
             mergeMap((mosaic: Mosaic) => this.mosaicsView([mosaic.id]).pipe(
                 filter((_) => _.length !== 0),
                 map<MosaicView[], MosaicAmountView>((mosaicViews) => {
-                    return new MosaicAmountView(mosaicViews[0].mosaicInfo[0], mosaic.amount);
+                    return new MosaicAmountView(mosaicViews[0].mosaicInfo, mosaic.amount);
                 }),
             toArray())));
     }

--- a/test/service/MosaicService.spec.ts
+++ b/test/service/MosaicService.spec.ts
@@ -17,7 +17,6 @@
 import {expect} from 'chai';
 import {AccountHttp} from '../../src/infrastructure/AccountHttp';
 import {MosaicHttp} from '../../src/infrastructure/MosaicHttp';
-import {NamespaceHttp} from '../../src/infrastructure/NamespaceHttp';
 import {Address} from '../../src/model/account/Address';
 import {Mosaic} from '../../src/model/mosaic/Mosaic';
 import {MosaicId} from '../../src/model/mosaic/MosaicId';
@@ -32,7 +31,7 @@ describe('MosaicService', () => {
     it('mosaicsView', () => {
         const mosaicId = new MosaicId([3294802500, 2243684972]);
         const mosaicService = new MosaicService(
-            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL), new NamespaceHttp(conf.NIS2_URL));
+            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL));
         return mosaicService.mosaicsView([mosaicId]).subscribe((mosaicsView: MosaicView[]) => {
             const mosaicView = mosaicsView[0];
             expect(mosaicView.mosaicInfo).to.be.an.instanceof(MosaicInfo);
@@ -42,7 +41,7 @@ describe('MosaicService', () => {
     it('mosaicsView of no existing mosaicId', () => {
         const mosaicId = new MosaicId([1234, 1234]);
         const mosaicService = new MosaicService(
-            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL), new NamespaceHttp(conf.NIS2_URL));
+            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL));
         return mosaicService.mosaicsView([mosaicId]).subscribe((mosaicsView: MosaicView[]) => {
             expect(mosaicsView.length).to.be.equal(0);
         });
@@ -50,7 +49,7 @@ describe('MosaicService', () => {
 
     it('mosaicsAmountView', () => {
         const mosaicService = new MosaicService(
-            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL), new NamespaceHttp(conf.NIS2_URL));
+            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL));
         return mosaicService.mosaicsAmountViewFromAddress(Address.createFromRawAddress('SARNASAS2BIAB6LMFA3FPMGBPGIJGK6IJETM3ZSP'))
             .subscribe((mosaicsAmountView: MosaicAmountView[]) => {
                 const mosaicAmountView = mosaicsAmountView[0];
@@ -60,7 +59,7 @@ describe('MosaicService', () => {
 
     it('mosaicsAmountView of no existing account', () => {
         const mosaicService = new MosaicService(
-            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL), new NamespaceHttp(conf.NIS2_URL));
+            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL));
         return mosaicService.mosaicsAmountViewFromAddress(Address.createFromRawAddress('SCKBZAMIQ6F46QMZUANE6E33KA63KA7KEQ5X6WJW'))
             .subscribe((mosaicsAmountView: MosaicAmountView[]) => {
                 expect(mosaicsAmountView.length).to.be.equal(0);
@@ -70,7 +69,7 @@ describe('MosaicService', () => {
     it('mosaicsAmountView', () => {
         const mosaic = new Mosaic(new MosaicId([3646934825, 3576016193]), UInt64.fromUint(1000));
         const mosaicService = new MosaicService(
-            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL), new NamespaceHttp(conf.NIS2_URL));
+            new AccountHttp(conf.NIS2_URL), new MosaicHttp(conf.NIS2_URL));
         return mosaicService.mosaicsAmountView([mosaic]).subscribe((mosaicsAmountView: MosaicAmountView[]) => {
             const mosaicAmountView = mosaicsAmountView[0];
             expect(mosaicAmountView.mosaicInfo).to.be.an.instanceof(MosaicInfo);


### PR DESCRIPTION

Fixes issue #82 : MosaicService is broken.

- `MosaicService.mosaicAmountView()` must pass single instance of `MosaicInfo` instead of `MosaicInfo[]`.