### PR TITLE
Bugfix: handling of unlimited duration mosaics

### DIFF
--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -158,7 +158,9 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
             new MosaicProperties(
                 new UInt64(transactionDTO.properties[0].value),
                 (new UInt64(transactionDTO.properties[1].value)).compact(),
-                transactionDTO.properties.length === 3 ? new UInt64(transactionDTO.properties[2].value) : undefined,
+                transactionDTO.properties.length === 3 
+                    ? new UInt64(transactionDTO.properties[2].value) 
+                    : UInt64_1.UInt64.fromUint(0),
             ),
             transactionDTO.signature,
             transactionDTO.signer ? PublicAccount.createFromPublicKey(transactionDTO.signer,

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -158,7 +158,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
             new MosaicProperties(
                 new UInt64(transactionDTO.properties[0].value),
                 (new UInt64(transactionDTO.properties[1].value)).compact(),
-                new UInt64(transactionDTO.properties.length === 3 ? transactionDTO.properties[2].value : undefined),
+                transactionDTO.properties.length === 3 ? new UInt64(transactionDTO.properties[2].value) : undefined,
             ),
             transactionDTO.signature,
             transactionDTO.signer ? PublicAccount.createFromPublicKey(transactionDTO.signer,

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -158,9 +158,8 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
             new MosaicProperties(
                 new UInt64(transactionDTO.properties[0].value),
                 (new UInt64(transactionDTO.properties[1].value)).compact(),
-                transactionDTO.properties.length === 3 
-                    ? new UInt64(transactionDTO.properties[2].value) 
-                    : UInt64_1.UInt64.fromUint(0),
+                transactionDTO.properties.length === 3 &&  transactionDTO.properties[2].value ?
+                    new UInt64(transactionDTO.properties[2].value) : undefined,
             ),
             transactionDTO.signature,
             transactionDTO.signer ? PublicAccount.createFromPublicKey(transactionDTO.signer,


### PR DESCRIPTION
Fix: Error when an unlimited duration mosaic MOSAIC_DEFINITION is fetched through `accountHttp.transactions`

Reason: 
`new UInt64_1.UInt64(undefined is returned)`


Bug reproduction:
Use 
`accountHttp.transactions`

on the following account:
`AC1A6E1D8DE5B17D2C6B1293F1CAD3829EEACF38D09311BB3C8E5A880092DE26`

The transaction hash with an unlimited duration mosaic:
`"aggregateHash":"41AA28C4BEC707C09568AAA4C2CF432EE7F8B28E83BC8F5FE24DBF6A92A70042"`