### PR TITLE
v0.11.5: fixed maxFee compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.11.5] - 18-Apr-2019
+
+- Fixed #125, maxFee DTO value errors with in-aggregate MosaicSupplyChange and HashLock transactions  
+
 ## [0.11.4] - 17-Apr-2019
 
 - Fixed #117, Typo in AddressAliasTransaction and MosaicAliasTransaction comments

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the NEM2 (a.k.a Catapult)
 
 Due to a network upgrade with [catapult-server@cow](https://github.com/nemtech/catapult-server/releases/tag/v0.3.0.2) version, **transactions from Alpaca&Bison are not compatible anymore**.
 
-The upgrade to this SDK's [version v0.11.4](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.11.4) is mandatory for **cow compatibility**.
+The upgrade to this SDK's [version v0.11.5](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.11.5) is mandatory for **cow compatibility**.
 
 Other versions like [version v0.10.1-beta](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.10.1-beta) can be used for **bison** network version.
 
@@ -55,6 +55,7 @@ Please, use the following available resources to get help:
 
 Important versions listed below. Refer to the [Changelog](CHANGELOG.md) for a full history of the project.
 
+- [0.11.5](CHANGELOG.md#0115-18-Apr-2019) - **Cow compatible** - 18.04.2019
 - [0.11.4](CHANGELOG.md#0114-17-Apr-2019) - **Cow compatible** - 17.04.2019
 - [0.11.3](CHANGELOG.md#0113-10-Apr-2019) - **Cow compatible** - 10.04.2019
 - [0.11.2](CHANGELOG.md#0112-1-Apr-2019) - **Cow compatible** - 01.04.2019

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.11.4",
+  "version": "0.11.5",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
Fixed maxFee incompatibility with in-aggregate MosaicSupplyChange and in-aggregate HashLock transactions.

Upgraded to v0.11.5 and updated CHANGELOG and README.