### PR TITLE
Fixed #134 Account property filter modification improvement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ node_js:
   - "8"
   - "9"
   - "10"
-cache:
-  directories:
-    - "node_modules"
+# cache:
+#   directories:
+#     - "node_modules"
 before_script:
   - npm run build
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ node_js:
   - "8"
   - "9"
   - "10"
-# cache:
-#   directories:
-#     - "node_modules"
+cache:
+  directories:
+    - "node_modules"
 before_script:
   - npm run build
 script: 

--- a/src/model/transaction/AccountPropertyModification.ts
+++ b/src/model/transaction/AccountPropertyModification.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
+import { Address } from '../account/Address';
 import { PropertyModificationType } from '../account/PropertyModificationType';
+import { MosaicId } from '../mosaic/MosaicId';
+import { TransactionType } from './TransactionType';
 
 export class AccountPropertyModification<T> {
 
@@ -33,6 +36,38 @@ export class AccountPropertyModification<T> {
                  */
                 public readonly value: T) {
 
+    }
+
+    /**
+     * Create an address filter for account property modification
+     * @param modificationType - modification type. 0: Add, 1: Remove
+     * @param address - modification value (Address)
+     * @returns {AccountPropertyModification}
+     */
+    public static createForAddress(modificationType: PropertyModificationType,
+                                   address: Address): AccountPropertyModification<string> {
+        return new AccountPropertyModification<string>(modificationType, address.plain());
+    }
+    /**
+     * Create an mosaic filter for account property modification
+     * @param modificationType - modification type. 0: Add, 1: Remove
+     * @param mosaicId - modification value (Mosaic)
+     * @returns {AccountPropertyModification}
+     */
+    public static createForMosaic(modificationType: PropertyModificationType,
+                                  mosaicId: MosaicId): AccountPropertyModification<number[]> {
+    return new AccountPropertyModification<number[]>(modificationType, mosaicId.id.toDTO());
+    }
+
+    /**
+     * Create an entity type filter for account property modification
+     * @param modificationType - modification type. 0: Add, 1: Remove
+     * @param entityType - modification value (Transaction Type)
+     * @returns {AccountPropertyModification}
+     */
+    public static createForEntityType(modificationType: PropertyModificationType,
+                                      entityType: number): AccountPropertyModification<TransactionType> {
+    return new AccountPropertyModification<TransactionType>(modificationType, entityType);
     }
 
     /**

--- a/src/model/transaction/AccountPropertyTransaction.ts
+++ b/src/model/transaction/AccountPropertyTransaction.ts
@@ -14,17 +14,15 @@
  * limitations under the License.
  */
 
-import { Address } from '../account/Address';
-import { PropertyModificationType } from '../account/PropertyModificationType';
 import { PropertyType } from '../account/PropertyType';
 import { NetworkType } from '../blockchain/NetworkType';
-import { MosaicId } from '../mosaic/MosaicId';
 import { UInt64 } from '../UInt64';
 import { AccountPropertyModification } from './AccountPropertyModification';
 import { Deadline } from './Deadline';
 import { ModifyAccountPropertyAddressTransaction } from './ModifyAccountPropertyAddressTransaction';
 import { ModifyAccountPropertyEntityTypeTransaction } from './ModifyAccountPropertyEntityTypeTransaction';
 import { ModifyAccountPropertyMosaicTransaction } from './ModifyAccountPropertyMosaicTransaction';
+import { TransactionType } from './TransactionType';
 
 export class AccountPropertyTransaction {
     /**
@@ -95,7 +93,7 @@ export class AccountPropertyTransaction {
     public static createEntityTypePropertyModificationTransaction(
         deadline: Deadline,
         propertyType: PropertyType,
-        modifications: Array<AccountPropertyModification<number>>,
+        modifications: Array<AccountPropertyModification<TransactionType>>,
         networkType: NetworkType,
         maxFee: UInt64 = new UInt64([0, 0])
     ): ModifyAccountPropertyEntityTypeTransaction {
@@ -109,38 +107,5 @@ export class AccountPropertyTransaction {
             networkType,
             maxFee,
         );
-    }
-
-    /**
-     * Create an address filter for account property modification
-     * @param modificationType - modification type. 0: Add, 1: Remove
-     * @param address - modification value (Address)
-     * @returns {AccountPropertyModification}
-     */
-    public static createAddressFilter(modificationType: PropertyModificationType,
-                                      address: Address): AccountPropertyModification<string> {
-        return new AccountPropertyModification<string>(modificationType, address.plain());
-    }
-
-    /**
-     * Create an mosaic filter for account property modification
-     * @param modificationType - modification type. 0: Add, 1: Remove
-     * @param mosaicId - modification value (Mosaic)
-     * @returns {AccountPropertyModification}
-     */
-    public static createMosaicFilter(modificationType: PropertyModificationType,
-                                     mosaicId: MosaicId): AccountPropertyModification<number[]> {
-        return new AccountPropertyModification<number[]>(modificationType, mosaicId.id.toDTO());
-    }
-
-    /**
-     * Create an entity type filter for account property modification
-     * @param modificationType - modification type. 0: Add, 1: Remove
-     * @param entityType - modification value (Transaction Type)
-     * @returns {AccountPropertyModification}
-     */
-    public static createEntityTypeFilter(modificationType: PropertyModificationType,
-                                         entityType: number): AccountPropertyModification<number> {
-        return new AccountPropertyModification<number>(modificationType, entityType);
     }
 }

--- a/src/model/transaction/ModifyAccountPropertyEntityTypeTransaction.ts
+++ b/src/model/transaction/ModifyAccountPropertyEntityTypeTransaction.ts
@@ -40,7 +40,7 @@ export class ModifyAccountPropertyEntityTypeTransaction extends Transaction {
      */
     public static create(deadline: Deadline,
                          propertyType: PropertyType,
-                         modifications: Array<AccountPropertyModification<number>>,
+                         modifications: Array<AccountPropertyModification<TransactionType>>,
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): ModifyAccountPropertyEntityTypeTransaction {
         return new ModifyAccountPropertyEntityTypeTransaction(networkType,
@@ -68,7 +68,7 @@ export class ModifyAccountPropertyEntityTypeTransaction extends Transaction {
                 deadline: Deadline,
                 maxFee: UInt64,
                 public readonly propertyType: PropertyType,
-                public readonly modifications: Array<AccountPropertyModification<number>>,
+                public readonly modifications: Array<AccountPropertyModification<TransactionType>>,
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -34,6 +34,7 @@ import { AliasActionType } from '../../../src/model/namespace/AliasActionType';
 import { NamespaceId } from '../../../src/model/namespace/NamespaceId';
 import { NamespaceType } from '../../../src/model/namespace/NamespaceType';
 import { AccountLinkTransaction } from '../../../src/model/transaction/AccountLinkTransaction';
+import { AccountPropertyModification } from '../../../src/model/transaction/AccountPropertyModification';
 import { AccountPropertyTransaction } from '../../../src/model/transaction/AccountPropertyTransaction';
 import { AddressAliasTransaction } from '../../../src/model/transaction/AddressAliasTransaction';
 import { AggregateTransaction } from '../../../src/model/transaction/AggregateTransaction';
@@ -67,7 +68,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
     it('should create AccountPropertyAddressTransaction', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -89,7 +90,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -111,7 +112,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const entityType = TransactionType.ADDRESS_ALIAS;
-        const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+        const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
             PropertyModificationType.Add,
             entityType,
         );
@@ -588,7 +589,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
 
     it('should create AccountPropertyAddressTransaction', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -609,7 +610,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -630,7 +631,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const entityType = TransactionType.ADDRESS_ALIAS;
-        const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+        const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
             PropertyModificationType.Add,
             entityType,
         );

--- a/test/infrastructure/SerializeTransactionToJSON.spec.ts
+++ b/test/infrastructure/SerializeTransactionToJSON.spec.ts
@@ -34,6 +34,7 @@ import { AliasActionType } from '../../src/model/namespace/AliasActionType';
 import { NamespaceId } from '../../src/model/namespace/NamespaceId';
 import { NamespaceType } from '../../src/model/namespace/NamespaceType';
 import { AccountLinkTransaction } from '../../src/model/transaction/AccountLinkTransaction';
+import { AccountPropertyModification } from '../../src/model/transaction/AccountPropertyModification';
 import { AccountPropertyTransaction } from '../../src/model/transaction/AccountPropertyTransaction';
 import { AddressAliasTransaction } from '../../src/model/transaction/AddressAliasTransaction';
 import { AggregateTransaction } from '../../src/model/transaction/AggregateTransaction';
@@ -80,7 +81,7 @@ describe('SerializeTransactionToJSON', () => {
 
     it('should create AccountPropertyAddressTransaction', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -100,7 +101,7 @@ describe('SerializeTransactionToJSON', () => {
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -120,7 +121,7 @@ describe('SerializeTransactionToJSON', () => {
 
     it('should create AccountPropertyMosaicTransaction', () => {
         const entityType = TransactionType.ADDRESS_ALIAS;
-        const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+        const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
             PropertyModificationType.Add,
             entityType,
         );

--- a/test/model/transaction/AccountPropertyTransaction.spec.ts
+++ b/test/model/transaction/AccountPropertyTransaction.spec.ts
@@ -17,11 +17,14 @@
 import {expect} from 'chai';
 import {Account} from '../../../src/model/account/Account';
 import {Address} from '../../../src/model/account/Address';
+import { PropertyModificationType } from '../../../src/model/account/PropertyModificationType';
+import { PropertyType } from '../../../src/model/account/PropertyType';
 import {NetworkType} from '../../../src/model/blockchain/NetworkType';
-import { PropertyModificationType, PropertyType, TransactionType } from '../../../src/model/model';
 import {MosaicId} from '../../../src/model/mosaic/MosaicId';
+import { AccountPropertyModification } from '../../../src/model/transaction/AccountPropertyModification';
 import {AccountPropertyTransaction} from '../../../src/model/transaction/AccountPropertyTransaction';
 import {Deadline} from '../../../src/model/transaction/Deadline';
+import { TransactionType } from '../../../src/model/transaction/TransactionType';
 import {UInt64} from '../../../src/model/UInt64';
 import {TestingAccount} from '../../conf/conf.spec';
 
@@ -33,7 +36,7 @@ describe('AccountPropertyTransaction', () => {
     });
     it('should create address property filter', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -43,7 +46,7 @@ describe('AccountPropertyTransaction', () => {
 
     it('should create mosaic property filter', () => {
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -54,7 +57,7 @@ describe('AccountPropertyTransaction', () => {
 
     it('should create entity type property filter', () => {
         const entityType = TransactionType.ADDRESS_ALIAS;
-        const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+        const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
             PropertyModificationType.Add,
             entityType,
         );
@@ -65,7 +68,7 @@ describe('AccountPropertyTransaction', () => {
     describe('size', () => {
         it('should return 148 for ModifyAccountPropertyAddressTransaction transaction byte size with 1 modification', () => {
             const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-            const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+            const addressPropertyFilter = AccountPropertyModification.createForAddress(
                 PropertyModificationType.Add,
                 address,
             );
@@ -81,7 +84,7 @@ describe('AccountPropertyTransaction', () => {
 
         it('should return 131 for ModifyAccountPropertyMosaicTransaction transaction byte size with 1 modification', () => {
             const mosaicId = new MosaicId([2262289484, 3405110546]);
-            const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+            const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
                 PropertyModificationType.Add,
                 mosaicId,
             );
@@ -96,7 +99,7 @@ describe('AccountPropertyTransaction', () => {
 
         it('should return 125 for ModifyAccountPropertyEntityTypeTransaction transaction byte size with 1 modification', () => {
             const entityType = TransactionType.ADDRESS_ALIAS;
-            const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+            const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
                 PropertyModificationType.Add,
                 entityType,
             );
@@ -110,10 +113,9 @@ describe('AccountPropertyTransaction', () => {
         });
     });
 
-
     it('should default maxFee field be set to 0', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -130,7 +132,7 @@ describe('AccountPropertyTransaction', () => {
 
     it('should filled maxFee override transaction maxFee', () => {
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -139,7 +141,7 @@ describe('AccountPropertyTransaction', () => {
             PropertyType.AllowAddress,
             [addressPropertyFilter],
             NetworkType.MIJIN_TEST,
-            new UInt64([1, 0])
+            new UInt64([1, 0]),
         );
 
         expect(addressPropertyTransaction.maxFee.higher).to.be.equal(0);
@@ -149,7 +151,7 @@ describe('AccountPropertyTransaction', () => {
     it('should create address property transaction', () => {
 
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -172,7 +174,7 @@ describe('AccountPropertyTransaction', () => {
     it('should throw exception when create address property transaction with wrong type', () => {
 
         const address = Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC');
-        const addressPropertyFilter = AccountPropertyTransaction.createAddressFilter(
+        const addressPropertyFilter = AccountPropertyModification.createForAddress(
             PropertyModificationType.Add,
             address,
         );
@@ -191,7 +193,7 @@ describe('AccountPropertyTransaction', () => {
     it('should create mosaic property transaction', () => {
 
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -214,7 +216,7 @@ describe('AccountPropertyTransaction', () => {
     it('should throw exception when create mosaic property transaction with wrong type', () => {
 
         const mosaicId = new MosaicId([2262289484, 3405110546]);
-        const mosaicPropertyFilter = AccountPropertyTransaction.createMosaicFilter(
+        const mosaicPropertyFilter = AccountPropertyModification.createForMosaic(
             PropertyModificationType.Add,
             mosaicId,
         );
@@ -233,7 +235,7 @@ describe('AccountPropertyTransaction', () => {
     it('should create entity type property transaction', () => {
 
         const entityType = TransactionType.ADDRESS_ALIAS;
-        const entityTypePropertyFilter = AccountPropertyTransaction.createEntityTypeFilter(
+        const entityTypePropertyFilter = AccountPropertyModification.createForEntityType(
             PropertyModificationType.Add,
             entityType,
         );


### PR DESCRIPTION
Issue: #134 

- Moved filter modification creation out of `AccountPropertyTransaction`.
- Modification class is `AccountPropertyModification`
- Now support both constructor creation and static method creation.
      `new AccountPropertyModification(PropertyModificationType, T)` 

      or
     
      AccountPropertyModification.createForAddress(PropertyModificationType, Address)
      AccountPropertyModification.createForMosaic(PropertyModificationType, Mosaic)
      AccountPropertyModification.createForEntityType(PropertyModificationType, entityType)
      
