### PR TITLE
v0.13.0: base compatibility for Elephant protocol upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.13.0] - 03-Jul-2019
+
+**Milestone**: Elephant
+
+- Added SignSchema to make KeyPair generation compatible with either of Catapult and NIS.
+- Added SignSchema with KECCAK_REVERSED_KEY and SHA3. The SDK by default uses SHA3 which is the Catapult signature schema.
+- Fixed transaction versions back to version 1
+- Added `signTransactionGivenSignatures` to cope with off chain aggregated complete transaction co signing.
+
 ## [0.12.4] - 03-Jul-2019
 
 **Milestone**: Dragon
@@ -143,7 +152,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
-
+[0.13.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.12.4...v0.13.0
 [0.12.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.12.3...v0.12.4
 [0.12.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.12.2...v0.12.3
 [0.12.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.12.1...v0.12.2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
+### _Elephant Network Compatibility (catapult-server@0.5.0.1)
+
+Due to a network upgrade with [catapult-server@elephant](https://github.com/nemtech/catapult-server/releases/tag/v0.5.0.1) version, **it is recommended to use this package's 0.13.0 version and upwards to use this package with Dragon versioned networks**.
+
+The upgrade to this package's [version v0.13.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.13.0) is mandatory for **dragon compatibility**.
+
 ### _Dragon_ Network Compatibility (catapult-server@0.4.0.1)
 
 Due to a network upgrade with [catapult-server@dragon](https://github.com/nemtech/catapult-server/releases/tag/v0.4.0.1) version, **it is recommended to use this package's 0.12.4 version and upwards to use this package with Dragon versioned networks**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.12.4",
+  "version": "0.13.0",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
**Milestone**: Elephant

- Added SignSchema to make KeyPair generation compatible with either of Catapult and NIS.
- Added SignSchema with KECCAK_REVERSED_KEY and SHA3. The SDK by default uses SHA3 which is the Catapult signature schema.
- Fixed transaction versions back to version 1
- Added `signTransactionGivenSignatures` to cope with off chain aggregated complete transaction co signing.