### PR TITLE
Task/g195 rxjs compatibility reopen

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
-### _Elephant Network Compatibility (catapult-server@0.5.0.1)
+### _Elephant_ Network Compatibility (catapult-server@0.5.0.1)
 
-Due to a network upgrade with [catapult-server@elephant](https://github.com/nemtech/catapult-server/releases/tag/v0.5.0.1) version, **it is recommended to use this package's 0.13.0 version and upwards to use this package with Dragon versioned networks**.
+Due to a network upgrade with [catapult-server@elephant](https://github.com/nemtech/catapult-server/releases/tag/v0.5.0.1) version, **it is recommended to use this package's 0.13.0 version and upwards to use this package with Elephant versioned networks**.
 
-The upgrade to this package's [version v0.13.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.13.0) is mandatory for **dragon compatibility**.
+The upgrade to this package's [version v0.13.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.13.0) is mandatory for **elephant compatibility**.
 
 ### _Dragon_ Network Compatibility (catapult-server@0.4.0.1)
 

--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -19,6 +19,7 @@ import {ChronoUnit} from 'js-joda';
 import {keccak_256, sha3_256} from 'js-sha3';
 import {Crypto} from '../../src/core/crypto';
 import { Convert as convert } from '../../src/core/format';
+import { TransactionMapping } from '../../src/core/utils/TransactionMapping';
 import {AccountHttp} from '../../src/infrastructure/AccountHttp';
 import { NamespaceHttp } from '../../src/infrastructure/infrastructure';
 import {Listener} from '../../src/infrastructure/Listener';
@@ -45,6 +46,7 @@ import { AccountRestrictionTransaction } from '../../src/model/transaction/Accou
 import { AddressAliasTransaction } from '../../src/model/transaction/AddressAliasTransaction';
 import {AggregateTransaction} from '../../src/model/transaction/AggregateTransaction';
 import {CosignatureSignedTransaction} from '../../src/model/transaction/CosignatureSignedTransaction';
+import { CosignatureTransaction } from '../../src/model/transaction/CosignatureTransaction';
 import {Deadline} from '../../src/model/transaction/Deadline';
 import { HashLockTransaction } from '../../src/model/transaction/HashLockTransaction';
 import {HashType} from '../../src/model/transaction/HashType';
@@ -1758,6 +1760,67 @@ describe('TransactionHttp', () => {
                 done();
             });
             transactionHttp.announce(secretLockTransaction.signWith(account, generationHash));
+        });
+    });
+
+    describe('SignTransactionGivenSignatures', () => {
+        let listener: Listener;
+        before (() => {
+            listener = new Listener(config.apiUrl);
+            return listener.open();
+        });
+        after(() => {
+            return listener.close();
+        });
+        it('Announce cosign signatures given', (done) => {
+
+            /**
+             * @see https://github.com/nemtech/nem2-sdk-typescript-javascript/issues/112
+             */
+            // AliceAccount: account
+            // BobAccount: account
+
+            const sendAmount = NetworkCurrencyMosaic.createRelative(1000);
+            const backAmount = NetworkCurrencyMosaic.createRelative(1);
+
+            const aliceTransferTransaction = TransferTransaction.create(Deadline.create(), account2.address, [sendAmount],
+                                                                        PlainMessage.create('payout'), NetworkType.MIJIN_TEST);
+            const bobTransferTransaction   = TransferTransaction.create(Deadline.create(), account.address, [backAmount],
+                                                                        PlainMessage.create('payout'), NetworkType.MIJIN_TEST);
+
+            // 01. Alice creates the aggregated tx and sign it. Then payload send to Bob
+            const aggregateTransaction = AggregateTransaction.createComplete(
+                Deadline.create(),
+                [
+                    aliceTransferTransaction.toAggregate(account.publicAccount),
+                    bobTransferTransaction.toAggregate(account2.publicAccount),
+                ],
+                NetworkType.MIJIN_TEST,
+                [],
+            );
+
+            const aliceSignedTransaction = aggregateTransaction.signWith(account, generationHash);
+
+            // 02 Bob cosigns the tx and sends it back to Alice
+            const signedTxBob = CosignatureTransaction.signTransactionPayload(account2, aliceSignedTransaction.payload, generationHash);
+
+            // 03. Alice collects the cosignatures, recreate, sign, and announces the transaction
+            const cosignatureSignedTransactions = [
+                new CosignatureSignedTransaction(signedTxBob.parentHash, signedTxBob.signature, signedTxBob.signer),
+            ];
+            const recreatedTx = TransactionMapping.createFromPayload(aliceSignedTransaction.payload) as AggregateTransaction;
+
+            const signedTransaction = recreatedTx.signTransactionGivenSignatures(account, cosignatureSignedTransactions, generationHash);
+
+            listener.confirmed(account.address).subscribe(() => {
+                done();
+            });
+            listener.status(account.address).subscribe((error) => {
+                console.log('Error:', error);
+                assert(false);
+                done();
+            });
+            transactionHttp.announce(signedTransaction);
         });
     });
 

--- a/src/infrastructure/ChainHttp.ts
+++ b/src/infrastructure/ChainHttp.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {from as observableFrom, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import { ClientResponse } from 'http';
+import {from as observableFrom, Observable, throwError} from 'rxjs';
+import {catchError, map} from 'rxjs/operators';
 import {BlockchainScore} from '../model/blockchain/BlockchainScore';
 import {UInt64} from '../model/UInt64';
 import { BlockchainScoreDTO,
@@ -50,9 +51,13 @@ export class ChainHttp extends Http implements ChainRepository {
      * @returns Observable<UInt64>
      */
     public getBlockchainHeight(): Observable<UInt64> {
-        return observableFrom(this.chainRoutesApi.getBlockchainHeight()).pipe(map((heightDTO: HeightInfoDTO) => {
-            return new UInt64(heightDTO.height);
-        }));
+        return observableFrom(this.chainRoutesApi.getBlockchainHeight()).pipe(
+            map((response: { response: ClientResponse; body: HeightInfoDTO; } ) => {
+                const heightDTO = response.body;
+                return new UInt64(heightDTO.height);
+            }),
+            catchError((error) =>  throwError(this.errorHandling(error))),
+        );
     }
 
     /**
@@ -60,11 +65,15 @@ export class ChainHttp extends Http implements ChainRepository {
      * @returns Observable<BlockchainScore>
      */
     public getBlockchainScore(): Observable<BlockchainScore> {
-        return observableFrom(this.chainRoutesApi.getBlockchainScore()).pipe(map((blockchainScoreDTO: BlockchainScoreDTO) => {
-            return new BlockchainScore(
-                new UInt64(blockchainScoreDTO.scoreLow),
-                new UInt64(blockchainScoreDTO.scoreHigh),
-            );
-        }));
+        return observableFrom(this.chainRoutesApi.getBlockchainScore()).pipe(
+            map((response: { response: ClientResponse; body: BlockchainScoreDTO; } ) => {
+                const blockchainScoreDTO = response.body;
+                return new BlockchainScore(
+                    new UInt64(blockchainScoreDTO.scoreLow),
+                    new UInt64(blockchainScoreDTO.scoreHigh),
+                );
+            }),
+            catchError((error) =>  throwError(this.errorHandling(error))),
+        );
     }
 }

--- a/src/infrastructure/Http.ts
+++ b/src/infrastructure/Http.ts
@@ -57,4 +57,12 @@ export abstract class Http {
             order: queryParams ? queryParams.order : undefined,
         };
     }
+
+    errorHandling(error: any): Error {
+        const formattedError = {
+            statusCode: error.response.statusCode,
+            errorDetails: error.response.body,
+        };
+        return new Error(JSON.stringify(formattedError));
+    }
 }

--- a/src/infrastructure/Http.ts
+++ b/src/infrastructure/Http.ts
@@ -59,10 +59,13 @@ export abstract class Http {
     }
 
     errorHandling(error: any): Error {
-        const formattedError = {
-            statusCode: error.response.statusCode,
-            errorDetails: error.response.body,
-        };
-        return new Error(JSON.stringify(formattedError));
+        if (error.response && error.response.statusCode && error.response.body) {
+            const formattedError = {
+                statusCode: error.response.statusCode,
+                errorDetails: error.response.body,
+            };
+            return new Error(JSON.stringify(formattedError));
+        }
+        return new Error(error);
     }
 }

--- a/src/infrastructure/MosaicHttp.ts
+++ b/src/infrastructure/MosaicHttp.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {from as observableFrom, Observable} from 'rxjs';
-import {map, mergeMap} from 'rxjs/operators';
+import { ClientResponse } from 'http';
+import {from as observableFrom, Observable, throwError} from 'rxjs';
+import {catchError, map, mergeMap} from 'rxjs/operators';
 import {PublicAccount} from '../model/account/PublicAccount';
 import {MosaicId} from '../model/mosaic/MosaicId';
 import {MosaicInfo} from '../model/mosaic/MosaicInfo';
@@ -61,33 +62,38 @@ export class MosaicHttp extends Http implements MosaicRepository {
     public getMosaic(mosaicId: MosaicId): Observable<MosaicInfo> {
         return this.getNetworkTypeObservable().pipe(
             mergeMap((networkType) => observableFrom(
-                this.mosaicRoutesApi.getMosaic(mosaicId.toHex())).pipe(map((mosaicInfoDTO: MosaicInfoDTO) => {
-                    let mosaicFlag;
-                    let divisibility;
-                    let duration;
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value) {
-                        mosaicFlag = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value;
-                    }
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value) {
-                        divisibility = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
-                    }
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value) {
-                        duration = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
-                    }
-                    return new MosaicInfo(
-                        mosaicInfoDTO.meta.id,
-                        new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
-                        new UInt64(mosaicInfoDTO.mosaic.supply),
-                        new UInt64(mosaicInfoDTO.mosaic.height),
-                        PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
-                        mosaicInfoDTO.mosaic.revision,
-                        new MosaicProperties(
-                            mosaicFlag ? new UInt64(mosaicFlag) : UInt64.fromUint(0),
-                            (divisibility ? new UInt64(divisibility) : UInt64.fromUint(0)).compact(),
-                            duration ? new UInt64(duration) : undefined,
-                        ),
-                );
-            }))));
+                this.mosaicRoutesApi.getMosaic(mosaicId.toHex())).pipe(
+                    map((response: { response: ClientResponse; body: MosaicInfoDTO; } ) => {
+                        const mosaicInfoDTO = response.body;
+                        let mosaicFlag;
+                        let divisibility;
+                        let duration;
+                        if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value) {
+                            mosaicFlag = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value;
+                        }
+                        if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value) {
+                            divisibility = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
+                        }
+                        if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value) {
+                            duration = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
+                        }
+                        return new MosaicInfo(
+                            mosaicInfoDTO.meta.id,
+                            new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
+                            new UInt64(mosaicInfoDTO.mosaic.supply),
+                            new UInt64(mosaicInfoDTO.mosaic.height),
+                            PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
+                            mosaicInfoDTO.mosaic.revision,
+                            new MosaicProperties(
+                                mosaicFlag ? new UInt64(mosaicFlag) : UInt64.fromUint(0),
+                                (divisibility ? new UInt64(divisibility) : UInt64.fromUint(0)).compact(),
+                                duration ? new UInt64(duration) : undefined,
+                            ),
+                    );
+                }),
+                catchError((error) =>  throwError(this.errorHandling(error))),
+            )),
+        );
     }
 
     /**
@@ -101,35 +107,41 @@ export class MosaicHttp extends Http implements MosaicRepository {
         };
         return this.getNetworkTypeObservable().pipe(
             mergeMap((networkType) => observableFrom(
-                this.mosaicRoutesApi.getMosaics(mosaicIdsBody)).pipe(map((mosaicInfosDTO: MosaicInfoDTO[]) => {
-                return mosaicInfosDTO.map((mosaicInfoDTO) => {
-                    let mosaicFlag;
-                    let divisibility;
-                    let duration;
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value) {
-                        mosaicFlag = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value;
-                    }
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value) {
-                        divisibility = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
-                    }
-                    if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value) {
-                        duration = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value;
-                    }
-                    return new MosaicInfo(
-                        mosaicInfoDTO.meta.id,
-                        new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
-                        new UInt64(mosaicInfoDTO.mosaic.supply),
-                        new UInt64(mosaicInfoDTO.mosaic.height),
-                        PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
-                        mosaicInfoDTO.mosaic.revision,
-                        new MosaicProperties(
-                            mosaicFlag ? new UInt64(mosaicFlag) : UInt64.fromUint(0),
-                            (divisibility ? new UInt64(divisibility) : UInt64.fromUint(0)).compact(),
-                            duration ? new UInt64(duration) : undefined,
-                        ),
-                    );
-                });
-            }))));
+                this.mosaicRoutesApi.getMosaics(mosaicIdsBody)).pipe(
+                    map((response: { response: ClientResponse; body: MosaicInfoDTO[]; }) => {
+                        const mosaicInfosDTO = response.body;
+                        return mosaicInfosDTO.map((mosaicInfoDTO) => {
+                            let mosaicFlag;
+                            let divisibility;
+                            let duration;
+                            if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value) {
+                                mosaicFlag = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.MosaicFlags].value;
+                            }
+                            if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value) {
+                                divisibility = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Divisibility].value;
+                            }
+                            if (mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value) {
+                                duration = mosaicInfoDTO.mosaic.properties[MosaicPropertyType.Duration].value;
+                            }
+                            return new MosaicInfo(
+                                mosaicInfoDTO.meta.id,
+                                new MosaicId(mosaicInfoDTO.mosaic.mosaicId),
+                                new UInt64(mosaicInfoDTO.mosaic.supply),
+                                new UInt64(mosaicInfoDTO.mosaic.height),
+                                PublicAccount.createFromPublicKey(mosaicInfoDTO.mosaic.owner, networkType),
+                                mosaicInfoDTO.mosaic.revision,
+                                new MosaicProperties(
+                                    mosaicFlag ? new UInt64(mosaicFlag) : UInt64.fromUint(0),
+                                    (divisibility ? new UInt64(divisibility) : UInt64.fromUint(0)).compact(),
+                                    duration ? new UInt64(duration) : undefined,
+                                ),
+                            );
+                        });
+                    }),
+                    catchError((error) =>  throwError(this.errorHandling(error))),
+                ),
+            ),
+        );
     }
 
     /**
@@ -143,15 +155,19 @@ export class MosaicHttp extends Http implements MosaicRepository {
             mosaicIds: mosaicIds.map((id) => id.toHex()),
         };
         return observableFrom(
-            this.mosaicRoutesApi.getMosaicsNames(mosaicIdsBody)).pipe(map((mosaics: MosaicNamesDTO[]) => {
-            return mosaics.map((mosaic) => {
-                return new MosaicNames(
-                    new MosaicId(mosaic.mosaicId),
-                    mosaic.names.map((name) => {
-                       return new NamespaceName(new NamespaceId(name), name);
-                    }),
-                );
-            });
-        }));
+            this.mosaicRoutesApi.getMosaicsNames(mosaicIdsBody)).pipe(
+                map((response: { response: ClientResponse; body: MosaicNamesDTO[]; }) => {
+                    const mosaics = response.body;
+                    return mosaics.map((mosaic) => {
+                        return new MosaicNames(
+                            new MosaicId(mosaic.mosaicId),
+                            mosaic.names.map((name) => {
+                            return new NamespaceName(new NamespaceId(name), name);
+                            }),
+                        );
+                    });
+                }),
+                catchError((error) =>  throwError(this.errorHandling(error))),
+            );
     }
 }

--- a/src/infrastructure/NetworkHttp.ts
+++ b/src/infrastructure/NetworkHttp.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {from as observableFrom, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import { ClientResponse } from 'http';
+import {from as observableFrom, Observable, throwError} from 'rxjs';
+import {catchError, map} from 'rxjs/operators';
 import {NetworkType} from '../model/blockchain/NetworkType';
 import { NetworkRoutesApi, NetworkTypeDTO } from './api';
 import {Http} from './Http';
@@ -49,12 +50,16 @@ export class NetworkHttp extends Http implements NetworkRepository {
      * @return network type enum.
      */
     public getNetworkType(): Observable<NetworkType> {
-        return observableFrom(this.networkRoutesApi.getNetworkType()).pipe(map((networkTypeDTO: NetworkTypeDTO) => {
-            if (networkTypeDTO.name === 'mijinTest') {
-                return NetworkType.MIJIN_TEST;
-            } else {
-                throw new Error('network ' + networkTypeDTO.name + ' is not supported yet by the sdk');
-            }
-        }));
+        return observableFrom(this.networkRoutesApi.getNetworkType()).pipe(
+            map((response: { response: ClientResponse; body: NetworkTypeDTO; } ) => {
+                const networkTypeDTO = response.body;
+                if (networkTypeDTO.name === 'mijinTest') {
+                    return NetworkType.MIJIN_TEST;
+                } else {
+                    throw new Error('network ' + networkTypeDTO.name + ' is not supported yet by the sdk');
+                }
+            }),
+            catchError((error) =>  throwError(this.errorHandling(error))),
+        );
     }
 }

--- a/src/infrastructure/NodeHttp.ts
+++ b/src/infrastructure/NodeHttp.ts
@@ -14,8 +14,9 @@
  * limitations under the License.
  */
 
-import {from as observableFrom, Observable} from 'rxjs';
-import {map} from 'rxjs/operators';
+import { ClientResponse } from 'http';
+import {from as observableFrom, Observable, throwError} from 'rxjs';
+import {catchError, map} from 'rxjs/operators';
 import { NodeInfo } from '../model/node/NodeInfo';
 import { NodeTime } from '../model/node/NodeTime';
 import { NodeInfoDTO, NodeRoutesApi, NodeTimeDTO } from './api';
@@ -49,17 +50,21 @@ export class NodeHttp extends Http implements NodeRepository {
      * @summary Get the node information
      */
     public getNodeInfo(): Observable<NodeInfo> {
-        return observableFrom(this.nodeRoutesApi.getNodeInfo()).pipe(map((nodeInfoDTO: NodeInfoDTO) => {
-            return new NodeInfo(
-                nodeInfoDTO.publicKey,
-                nodeInfoDTO.port,
-                nodeInfoDTO.networkIdentifier,
-                nodeInfoDTO.version,
-                nodeInfoDTO.roles as number,
-                nodeInfoDTO.host,
-                nodeInfoDTO.friendlyName,
-            );
-        }));
+        return observableFrom(this.nodeRoutesApi.getNodeInfo()).pipe(
+            map((response: { response: ClientResponse; body: NodeInfoDTO; } ) => {
+                const nodeInfoDTO = response.body;
+                return new NodeInfo(
+                    nodeInfoDTO.publicKey,
+                    nodeInfoDTO.port,
+                    nodeInfoDTO.networkIdentifier,
+                    nodeInfoDTO.version,
+                    nodeInfoDTO.roles as number,
+                    nodeInfoDTO.host,
+                    nodeInfoDTO.friendlyName,
+                );
+            }),
+            catchError((error) =>  throwError(this.errorHandling(error))),
+        );
     }
 
     /**
@@ -67,8 +72,13 @@ export class NodeHttp extends Http implements NodeRepository {
      * @summary Get the node time
      */
     public getNodeTime(): Observable<NodeTime> {
-        return observableFrom(this.nodeRoutesApi.getNodeTime()).pipe(map((nodeTimeDTO: NodeTimeDTO) => {
-            return new NodeTime(nodeTimeDTO.communicationTimestamps.sendTimestamp, nodeTimeDTO.communicationTimestamps.receiveTimestamp);
-        }));
+        return observableFrom(this.nodeRoutesApi.getNodeTime()).pipe(
+            map((response: { response: ClientResponse; body: NodeTimeDTO; } ) => {
+                const nodeTimeDTO = response.body;
+                return new NodeTime(nodeTimeDTO.communicationTimestamps.sendTimestamp,
+                                    nodeTimeDTO.communicationTimestamps.receiveTimestamp);
+            }),
+            catchError((error) =>  throwError(this.errorHandling(error))),
+        );
     }
 }

--- a/src/infrastructure/TransactionHttp.ts
+++ b/src/infrastructure/TransactionHttp.ts
@@ -166,7 +166,7 @@ export class TransactionHttp extends Http implements TransactionRepository {
      */
     public announceAggregateBonded(signedTransaction: SignedTransaction): Observable<TransactionAnnounceResponse> {
         if (signedTransaction.type !== TransactionType.AGGREGATE_BONDED) {
-            throwError('Only Transaction Type 0x4241 is allowed for announce aggregate bonded');
+            throw new Error('Only Transaction Type 0x4241 is allowed for announce aggregate bonded');
         }
         return observableFrom(this.transactionRoutesApi.announcePartialTransaction(signedTransaction)).pipe(
             map((response: { response: ClientResponse; body: AnnounceTransactionInfoDTO; } ) => {

--- a/src/infrastructure/api/accountRoutesApi.ts
+++ b/src/infrastructure/api/accountRoutesApi.ts
@@ -136,12 +136,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "AccountInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -193,12 +190,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "MultisigAccountInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -250,12 +244,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<MultisigAccountGraphInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -307,12 +298,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "AccountRestrictionsInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -364,12 +352,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<AccountRestrictionsInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -421,12 +406,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<AccountInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -478,12 +460,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<AccountNamesDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -550,12 +529,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -622,12 +598,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -694,12 +667,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -766,12 +736,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -838,12 +805,9 @@ export class AccountRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/blockRoutesApi.ts
+++ b/src/infrastructure/api/blockRoutesApi.ts
@@ -133,12 +133,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "BlockInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -190,12 +187,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "StatementsDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -257,12 +251,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -321,12 +312,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<BlockInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -385,12 +373,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "MerkleProofInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -449,12 +434,9 @@ export class BlockRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "MerkleProofInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/chainRoutesApi.ts
+++ b/src/infrastructure/api/chainRoutesApi.ts
@@ -124,12 +124,9 @@ export class ChainRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "HeightInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -174,12 +171,9 @@ export class ChainRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "BlockchainScoreDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/diagnosticRoutesApi.ts
+++ b/src/infrastructure/api/diagnosticRoutesApi.ts
@@ -124,12 +124,9 @@ export class DiagnosticRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "StorageInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -174,12 +171,9 @@ export class DiagnosticRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "ServerDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/mosaicRoutesApi.ts
+++ b/src/infrastructure/api/mosaicRoutesApi.ts
@@ -132,12 +132,9 @@ export class MosaicRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "MosaicInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -189,12 +186,9 @@ export class MosaicRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<MosaicInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -246,12 +240,9 @@ export class MosaicRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<MosaicNamesDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/namespaceRoutesApi.ts
+++ b/src/infrastructure/api/namespaceRoutesApi.ts
@@ -133,12 +133,9 @@ export class NamespaceRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "NamespaceInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -200,12 +197,9 @@ export class NamespaceRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<NamespaceInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -267,12 +261,9 @@ export class NamespaceRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<NamespaceInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -324,12 +315,9 @@ export class NamespaceRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<NamespaceNameDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/networkRoutesApi.ts
+++ b/src/infrastructure/api/networkRoutesApi.ts
@@ -123,12 +123,9 @@ export class NetworkRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "NetworkTypeDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/nodeRoutesApi.ts
+++ b/src/infrastructure/api/nodeRoutesApi.ts
@@ -124,12 +124,9 @@ export class NodeRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "NodeInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -174,12 +171,9 @@ export class NodeRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "NodeTimeDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/api/transactionRoutesApi.ts
+++ b/src/infrastructure/api/transactionRoutesApi.ts
@@ -136,12 +136,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "AnnounceTransactionInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -193,12 +190,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "AnnounceTransactionInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -250,12 +244,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "AnnounceTransactionInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -307,12 +298,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "TransactionInfoDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -364,12 +352,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "TransactionStatusDTO");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -421,12 +406,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionInfoDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });
@@ -478,12 +460,9 @@ export class TransactionRoutesApi {
                 } else {
                     body = ObjectSerializer.deserialize(body, "Array<TransactionStatusDTO>");
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/infrastructure/builders/AggregateTransaction.ts
+++ b/src/infrastructure/builders/AggregateTransaction.ts
@@ -56,7 +56,7 @@ export class AggregateTransaction extends VerifiableTransaction {
         return signedTransaction;
     }
 
-    signTransactionGivenSignatures(initializer, cosignedSignedTransactions, generationHash, signSchema) {
+    signTransactionGivenSignatures(initializer, cosignedSignedTransactions, generationHash, signSchema = SignSchema.SHA3) {
         const signedTransaction = this.signTransaction(initializer, generationHash, signSchema);
         cosignedSignedTransactions.forEach((cosignedTransaction) => {
             signedTransaction.payload = signedTransaction.payload + cosignedTransaction.signer + cosignedTransaction.signature;

--- a/src/infrastructure/templates/api-single.mustache
+++ b/src/infrastructure/templates/api-single.mustache
@@ -219,12 +219,9 @@ export class {{classname}} {
                     body = ObjectSerializer.deserialize(body, "{{{returnType}}}");
                     {{/returnType}}
                     if (response.statusCode && response.statusCode >= 200 && response.statusCode <= 299) {
-                        resolve(body);
+                        resolve({ response, body });
                     } else {
-                        reject({
-                            statusCode: response.statusCode,
-                            statusMessage: response.statusMessage
-                        });
+                        reject({ response, body });
                     }
                 }
             });

--- a/src/model/account/Account.ts
+++ b/src/model/account/Account.ts
@@ -172,6 +172,21 @@ export class Account {
     }
 
     /**
+     * Sign transaction with cosignatories collected from cosigned transactions and creating a new SignedTransaction
+     * For off chain Aggregated Complete Transaction co-signing.
+     * @param initiatorAccount - Initiator account
+     * @param {CosignatureSignedTransaction[]} cosignatureSignedTransactions - Array of cosigned transaction
+     * @param generationHash - Network generation hash hex
+     * @param {SignSchema} signSchema The Sign Schema. (KECCAK_REVERSED_KEY / SHA3)
+     * @return {SignedTransaction}
+     */
+    public signTransactionGivenSignatures(transaction: AggregateTransaction,
+                                          cosignatureSignedTransactions: CosignatureSignedTransaction[],
+                                          generationHash: string,
+                                          signSchema: SignSchema = SignSchema.SHA3): SignedTransaction {
+    return transaction.signTransactionGivenSignatures(this, cosignatureSignedTransactions, generationHash, signSchema);
+    }
+    /**
      * Sign aggregate signature transaction
      * @param cosignatureTransaction - The aggregate signature transaction.
      * @param {SignSchema} signSchema The Sign Schema. (KECCAK_REVERSED_KEY / SHA3)

--- a/src/model/transaction/CosignatureTransaction.ts
+++ b/src/model/transaction/CosignatureTransaction.ts
@@ -15,11 +15,12 @@
  */
 
 import { SignSchema } from '../../core/crypto';
+import { Convert } from '../../core/format/Convert';
 import {CosignatureTransaction as CosignaturetransactionLibrary} from '../../infrastructure/builders/CosignatureTransaction';
+import { VerifiableTransaction } from '../../infrastructure/builders/VerifiableTransaction';
 import {Account} from '../account/Account';
 import {AggregateTransaction} from './AggregateTransaction';
 import {CosignatureSignedTransaction} from './CosignatureSignedTransaction';
-import { VerifiableTransaction } from '../../infrastructure/builders/VerifiableTransaction';
 
 /**
  * Cosignature transaction is used to sign an aggregate transactions with missing cosignatures.
@@ -52,16 +53,20 @@ export class CosignatureTransaction {
      * Creating a new CosignatureSignedTransaction
      * @param account - The signing account
      * @param payload - off transaction payload (aggregated transaction is unannounced)
-     * @param gernationHash - Network generation hash
+     * @param generationHash - Network generation hash
+     * @param {SignSchema} signSchema The Sign Schema. (KECCAK_REVERSED_KEY / SHA3)
      * @returns {CosignatureSignedTransaction}
      */
-    public static signTransactionPayload(account: Account, payload: string, gernationHash: string): CosignatureSignedTransaction {
+    public static signTransactionPayload(account: Account,
+                                         payload: string,
+                                         generationHash: string,
+                                         signSchema: SignSchema = SignSchema.SHA3): CosignatureSignedTransaction {
         /**
          * For aggregated complete transaction, cosignatories are gathered off chain announced.
          */
-        const transactionHash = VerifiableTransaction.createTransactionHash(payload, gernationHash);
+        const transactionHash = VerifiableTransaction.createTransactionHash(payload, Array.from(Convert.hexToUint8(generationHash)));
         const aggregateSignatureTransaction = new CosignaturetransactionLibrary(transactionHash);
-        const signedTransactionRaw = aggregateSignatureTransaction.signCosignatoriesTransaction(account);
+        const signedTransactionRaw = aggregateSignatureTransaction.signCosignatoriesTransaction(account, signSchema);
         return new CosignatureSignedTransaction(signedTransactionRaw.parentHash,
             signedTransactionRaw.signature,
             signedTransactionRaw.signer);

--- a/test/infrastructure/TransactionHttp.spec.ts
+++ b/test/infrastructure/TransactionHttp.spec.ts
@@ -46,12 +46,10 @@ describe('TransactionHttp', () => {
 
         const signedTx = account.sign(aggTx, generationHash);
         const trnsHttp = new TransactionHttp(NIS2_URL);
-        return trnsHttp.announceAggregateBonded(signedTx)
+        expect(() => {
+            trnsHttp.announceAggregateBonded(signedTx)
             .toPromise()
-            .then(() => {
-            })
-            .catch((reason) => {
-                expect(reason.toString()).to.be.equal('Only Transaction Type 0x4241 is allowed for announce aggregate bonded');
-            });
+            .then();
+        }).to.throw(Error, 'Only Transaction Type 0x4241 is allowed for announce aggregate bonded');
     });
 });

--- a/test/infrastructure/TransactionHttp.spec.ts
+++ b/test/infrastructure/TransactionHttp.spec.ts
@@ -49,7 +49,6 @@ describe('TransactionHttp', () => {
         return trnsHttp.announceAggregateBonded(signedTx)
             .toPromise()
             .then(() => {
-                throw new Error('Should be called');
             })
             .catch((reason) => {
                 expect(reason.toString()).to.be.equal('Only Transaction Type 0x4241 is allowed for announce aggregate bonded');


### PR DESCRIPTION
Issue #195 

#### Problem
After updated rxjs to the latest version (run `npm update`) it throw compile error on all http repositories. Latest version of Rxjs and typescript only support `strong` typed parameters. 

#### Fixes
- Update the swagger codegen typescript-node template with correct `resolve` & `reject` codes.
- Update Http repos with strong typed parameters matching the generated swagger codes. 
- Added errorHandling to parse useful error details. (generated swagger code returns the full http response).
- Tested on current & latest npm packages (after `npm update`) 