### PR TITLE
Added toString for UInt64 to allow representing a 64-bit integer as a string.

### DIFF
--- a/src/model/UInt64.ts
+++ b/src/model/UInt64.ts
@@ -90,18 +90,15 @@ export class UInt64 {
      * @return {string}
      */
     public toString(radix: number = 10): string {
-        var result = '';
-        var high = this.higher;
-        var low = this.lower;
-        while (true) {
-            var mod = (high % radix) * 0x100000000 + low;
+        let result = '';
+        let high = this.higher;
+        let low = this.lower;
+        do {
+            let mod = (high % radix) * 0x100000000 + low;
             high = Math.floor(high / radix);
             low = Math.floor(mod / radix);
             result = (mod % radix).toString(radix) + result;
-            if (!high && !low) {
-                break;
-            }
-        }
+        } while (high !== 0 || low !== 0);
         return result;
     }
 

--- a/src/model/UInt64.ts
+++ b/src/model/UInt64.ts
@@ -85,6 +85,27 @@ export class UInt64 {
     }
 
     /**
+     * Get string representation of number (by default, decimal representation)
+     *
+     * @return {string}
+     */
+    public toString(radix: number = 10): string {
+        var result = '';
+        var high = this.higher;
+        var low = this.lower;
+        while (true) {
+            var mod = (high % radix) * 0x100000000 + low;
+            high = Math.floor(high / radix);
+            low = Math.floor(mod / radix);
+            result = (mod % radix).toString(radix) + result;
+            if (!high && !low) {
+                break;
+            }
+        }
+        return result;
+    }
+
+    /**
      * Compact higher and lower uint parts into a uint
      * @returns {number}
      */

--- a/test/model/UInt64.spec.ts
+++ b/test/model/UInt64.spec.ts
@@ -122,4 +122,31 @@ describe('Uint64', () => {
             });
         });
     });
+
+    describe('toString', () => {
+        it('should be able to serialize to decimal notation with 2 values', () => {
+            const value = new UInt64([13, 12]);
+            expect(value.toString() === '51539607565').to.be.equal(true);
+        });
+
+        it('should be able to serialize to decimal notation with no higher value', () => {
+            const value = new UInt64([12, 0]);
+            expect(value.toString() === '12').to.be.equal(true);
+        });
+
+        it('should be able to serialize to decimal notation with no lower value', () => {
+            const value = new UInt64([0, 12]);
+            expect(value.toString() === '51539607552').to.be.equal(true);
+        });
+
+        it('should be able to serialize to decimal notation with an explicit radix', () => {
+            const value = new UInt64([13, 12]);
+            expect(value.toString(10) === '51539607565').to.be.equal(true);
+        });
+
+        it('should be able to serialize to binary notation', () => {
+            const value = new UInt64([13, 12]);
+            expect(value.toString(2) === '110000000000000000000000000000001101').to.be.equal(true);
+        });
+    });
 });


### PR DESCRIPTION
This is very useful for derived projects from the nem2-typescript-sdk, since it allows representing heights, fees, etc. as strings (useful for user-interfacess, keys for databases, etc.). It supports any radix, and defaults to 10.