### PR TITLE
fix #247

### DIFF
--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -14,8 +14,8 @@
  * limitations under the License.
  */
 
-import { Observable, of as observableOf } from 'rxjs';
-import { filter, first, map, mergeMap, take, toArray } from 'rxjs/operators';
+import { zip, from, Observable, of as observableOf } from 'rxjs';
+import { filter, first, map, mergeMap, take, toArray, concatMap, flatMap } from 'rxjs/operators';
 import { AccountHttp } from '../infrastructure/AccountHttp';
 import { MosaicHttp } from '../infrastructure/MosaicHttp';
 import { NamespaceHttp } from '../infrastructure/NamespaceHttp';
@@ -67,8 +67,8 @@ export class MosaicService {
                 toArray(),
                 concatMap(mosaics =>
                     zip(
-                        of(mosaics).pipe(flatMap((_) => _)),
-                        of(mosaics)
+                        observableOf(mosaics).pipe(flatMap((_) => _)),
+                        observableOf(mosaics)
                             .pipe(
                                 flatMap((_) => _),
                                 map(mosaic => new MosaicId(mosaic.id.id.toDTO())),

--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -71,9 +71,9 @@ export class MosaicService {
                         observableOf(mosaics)
                             .pipe(
                                 flatMap((_) => _),
-                                map(mosaic => new MosaicId(mosaic.id.id.toDTO())),
+                                map((mosaic: Mosaic) => new MosaicId(mosaic.id.id.toDTO())),
                                 toArray(),
-                                mergeMap((mosaic) => this.mosaicsView(mosaic)),
+                                mergeMap((mosaics: Mosaic[]) => this.mosaicsView(mosaics)),
                                 flatMap((_) => _),
                             )
                     ).pipe(

--- a/src/service/MosaicService.ts
+++ b/src/service/MosaicService.ts
@@ -73,7 +73,7 @@ export class MosaicService {
                                 flatMap((_) => _),
                                 map((mosaic: Mosaic) => new MosaicId(mosaic.id.id.toDTO())),
                                 toArray(),
-                                mergeMap((mosaics: Mosaic[]) => this.mosaicsView(mosaics)),
+                                mergeMap((mosaicIds: MosaicId[]) => this.mosaicsView(mosaicIds)),
                                 flatMap((_) => _),
                             )
                     ).pipe(


### PR DESCRIPTION
This does the trick for me in the compiled file, it's much faster
I didn't try to build it on the SDK


working compiled version:

    mosaicsAmountView(mosaics) {
        return rxjs_1.from(mosaics)
            .pipe(
                operators_1.toArray(),
                operators_1.concatMap(mosaics =>
                    rxjs_1.zip(
                        rxjs_1.of(mosaics).pipe(operators_1.flatMap(x=>x)),
                        rxjs_1.of(mosaics)
                            .pipe(
                                operators_1.flatMap(x => x),
                                operators_1.map(mosaic => new MosaicId_1.MosaicId(mosaic.id.id.toDTO())),
                                operators_1.toArray(),
                                operators_1.mergeMap((mosaic) => this.mosaicsView(mosaic)),
                                operators_1.flatMap(x=>x)
                            )
                    ).pipe(
                        operators_1.map(([mosaic, mosaicView]) => {
                            return new MosaicAmountView_1.MosaicAmountView(mosaicView.mosaicInfo, mosaic.amount)
                           })
                        ),
                ),
                operators_1.toArray(),
            )
    }