### PR TITLE
Implement KeyGenerator

### DIFF
--- a/src/core/format/KeyGenerator.ts
+++ b/src/core/format/KeyGenerator.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018 NEM
+ * Copyright 2019 NEM
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,18 +19,16 @@ import { sha3_256 } from 'js-sha3';
 
 export class KeyGenerator {
     /**
+     * Generate UInt64 from a string
+     * @param {string} input Input string
      * @returns {UInt64} Deterministic uint64 value for the given string
      */
-    public static fromString(input: string) {
+    public static fromString(input: string): UInt64 {
         if (input.length === 0) {
             throw Error(`Input must not be empty`);
         }
         if (input.length > 1024) {
             throw Error(`Input exceeds 1024 characters (has ${input.length})`);
-        }
-        const format = /^[a-zA-Z0-9_]+$/gm;
-        if (input.match(format) === null) {
-            throw Error(`Input has invalid format (accepted characters: a-z, A-Z, 0-9, _)`);
         }
         const hex = sha3_256(input)
         return UInt64.fromHex(hex.substr(0, 16))

--- a/src/core/format/KeyGenerator.ts
+++ b/src/core/format/KeyGenerator.ts
@@ -23,14 +23,12 @@ export class KeyGenerator {
      * @param {string} input Input string
      * @returns {UInt64} Deterministic uint64 value for the given string
      */
-    public static fromString(input: string): UInt64 {
+    public static generateUInt64Key(input: string): UInt64 {
         if (input.length === 0) {
             throw Error(`Input must not be empty`);
         }
-        if (input.length > 1024) {
-            throw Error(`Input exceeds 1024 characters (has ${input.length})`);
-        }
-        const hex = sha3_256(input)
-        return UInt64.fromHex(hex.substr(0, 16))
+        const buf = sha3_256.arrayBuffer(input);
+        const result = new Uint32Array(buf);
+        return new UInt64([result[0], (result[1] | 0x80000000) >>> 0]);
     }
 }

--- a/src/core/format/KeyGenerator.ts
+++ b/src/core/format/KeyGenerator.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2018 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { UInt64 } from '../../model/UInt64';
+import { sha3_256 } from 'js-sha3';
+
+export class KeyGenerator {
+    /**
+     * @returns {UInt64} Deterministic uint64 value for the given string
+     */
+    public static fromString(input: string) {
+        if (input.length === 0) {
+            throw Error(`Input must not be empty`);
+        }
+        if (input.length > 1024) {
+            throw Error(`Input exceeds 1024 characters (has ${input.length})`);
+        }
+        const format = /^[a-zA-Z0-9_]+$/gm;
+        if (input.match(format) === null) {
+            throw Error(`Input has invalid format (accepted characters: a-z, A-Z, 0-9, _)`);
+        }
+        const hex = sha3_256(input)
+        return UInt64.fromHex(hex.substr(0, 16))
+    }
+}

--- a/src/core/format/index.ts
+++ b/src/core/format/index.ts
@@ -18,4 +18,5 @@ export * from './RawAddress';
 export * from './RawArray';
 export * from './Convert';
 export * from './IdGenerator';
+export * from './KeyGenerator';
 export * from './RawUInt64';

--- a/test/core/format/KeyGenerator.spec.ts
+++ b/test/core/format/KeyGenerator.spec.ts
@@ -25,11 +25,6 @@ describe('key generator', () => {
         it('returns UInt64', () => {
             expect(KeyGenerator.fromString('a')).to.be.instanceOf(UInt64);
         })
-        it('throws if input has invalid format', () => {
-            expect(() => KeyGenerator.fromString('$abc')).to.throw(Error, '');
-            expect(() => KeyGenerator.fromString('ab-c')).to.throw(Error, '');
-            expect(() => KeyGenerator.fromString('abc.')).to.throw(Error, '');
-        })
         it('generates correct keys', () => {
             expect(KeyGenerator.fromString('a').toHex()).to.equal('80084BF2FBA02475');
         })

--- a/test/core/format/KeyGenerator.spec.ts
+++ b/test/core/format/KeyGenerator.spec.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 NEM
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import { expect } from 'chai';
+import { UInt64 } from '../../../src/model/UInt64';
+import { KeyGenerator } from '../../../src/core/format/KeyGenerator';
+
+describe('key generator', () => {
+    describe('generate key from string', () => {
+        it('throws if input is empty', () => {
+            expect(() => KeyGenerator.fromString('')).to.throw(Error, 'Input must not be empty');
+        })
+        it('returns UInt64', () => {
+            expect(KeyGenerator.fromString('a')).to.be.instanceOf(UInt64);
+        })
+        it('throws if input has invalid format', () => {
+            expect(() => KeyGenerator.fromString('$abc')).to.throw(Error, '');
+            expect(() => KeyGenerator.fromString('ab-c')).to.throw(Error, '');
+            expect(() => KeyGenerator.fromString('abc.')).to.throw(Error, '');
+        })
+        it('generates correct keys', () => {
+            expect(KeyGenerator.fromString('a').toHex()).to.equal('80084BF2FBA02475');
+        })
+        it('generates keys deterministically', () => {
+            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
+            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
+            expect(KeyGenerator.fromString('def').toHex()).to.equal('8E0D8F672252ACB0');
+            expect(KeyGenerator.fromString('def').toHex()).to.equal('8E0D8F672252ACB0');
+            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
+        })
+    })
+});

--- a/test/core/format/KeyGenerator.spec.ts
+++ b/test/core/format/KeyGenerator.spec.ts
@@ -20,20 +20,20 @@ import { KeyGenerator } from '../../../src/core/format/KeyGenerator';
 describe('key generator', () => {
     describe('generate key from string', () => {
         it('throws if input is empty', () => {
-            expect(() => KeyGenerator.fromString('')).to.throw(Error, 'Input must not be empty');
+            expect(() => KeyGenerator.generateUInt64Key('')).to.throw(Error, 'Input must not be empty');
         })
         it('returns UInt64', () => {
-            expect(KeyGenerator.fromString('a')).to.be.instanceOf(UInt64);
+            expect(KeyGenerator.generateUInt64Key('a')).to.be.instanceOf(UInt64);
         })
         it('generates correct keys', () => {
-            expect(KeyGenerator.fromString('a').toHex()).to.equal('80084BF2FBA02475');
+            expect(KeyGenerator.generateUInt64Key('a').toHex()).to.equal('F524A0FBF24B0880');
         })
         it('generates keys deterministically', () => {
-            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
-            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
-            expect(KeyGenerator.fromString('def').toHex()).to.equal('8E0D8F672252ACB0');
-            expect(KeyGenerator.fromString('def').toHex()).to.equal('8E0D8F672252ACB0');
-            expect(KeyGenerator.fromString('abc').toHex()).to.equal('3A985DA74FE225B2');
+            expect(KeyGenerator.generateUInt64Key('abc').toHex()).to.equal('B225E24FA75D983A');
+            expect(KeyGenerator.generateUInt64Key('abc').toHex()).to.equal('B225E24FA75D983A');
+            expect(KeyGenerator.generateUInt64Key('def').toHex()).to.equal('B0AC5222678F0D8E');
+            expect(KeyGenerator.generateUInt64Key('def').toHex()).to.equal('B0AC5222678F0D8E');
+            expect(KeyGenerator.generateUInt64Key('abc').toHex()).to.equal('B225E24FA75D983A');
         })
     })
 });


### PR DESCRIPTION
PR adds `core/format/KeyGenerator`. Usage:

`const u64 = KeyGenerator.fromString('key_name') // returns UInt64`