### PR TITLE
v0.14.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.0] - 08-Oct-2019
+
+**Milestone**: Fuschicho
+
+- Added `KeyGenerator` class for generating UInt64 Keys from string.
+- Fixed `MosaicAmountView` issue. Now return observable of array.
+- Optimised `Account restriction` endpoints by returning simple payload.
+- Fixed http repository `error handling` issues.
+- Fixed bugs in `Alias` interface.
+- Fixed `MosaicId significant byte` not detected properly in TransactionPayload.
+- Fixed only `MIJIN_TEST` network type allowed in NetworkTypeHttp.
+- Applied latest OpenAPI doc (`v0.7.19`).
+- Changed `SignedTransaction` class constructor to public.
+- Changed `MosaicRestrictionKey` format to be Hexadecimal.
+- Other small fixes.
+
 ## [0.13.4] - 04-Oct-2019
 
 **Milestone**: Elephant.3 / Fuschicho
@@ -206,6 +222,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.14.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.4...v0.14.0
 [0.13.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.2...v0.13.3
 [0.13.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.1...v0.13.2

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
+### _Fuschicho_ Network Compatibility (catapult-server@0.8.0.3)
+
+Due to a network upgrade with [catapult-server@fuschicho](https://github.com/nemtech/catapult-server/releases/tag/v0.8.0.3) version, **it is recommended to use this package's 0.14.0 version and upwards to use this package with Fuschicho versioned networks**.
+
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 
 Due to a network upgrade with [catapult-server@elephant3](https://github.com/nemtech/catapult-server/releases/tag/v0.7.0.1) version, **it is recommended to use this package's 0.13.4 version and upwards to use this package with Elephant versioned networks**.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.13.4",
+  "version": "0.14.0",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
**Milestone**: Fuschicho

- Added `KeyGenerator` class for generating UInt64 Keys from string.
- Fixed `MosaicAmountView` issue. Now return observable of array.
- Optimised `Account restriction` endpoints by returning simple payload.
- Fixed http repository `error handling` issues.
- Fixed bugs in `Alias` interface.
- Fixed `MosaicId significant byte` not detected properly in TransactionPayload.
- Fixed only `MIJIN_TEST` network type allowed in NetworkTypeHttp.
- Applied latest OpenAPI doc (`v0.7.19`).
- Changed `SignedTransaction` class constructor to public.
- Changed `MosaicRestrictionKey` format to be Hexadecimal.
- Other small fixes.