### PR TITLE
JAV-38  Inner transaction singer delegation

### DIFF
--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -289,12 +289,19 @@ export class AggregateTransaction extends Transaction {
      * @internal
      * @returns {Uint8Array}
      */
-    protected generateBytes(): Uint8Array {
+    protected generateBytes(signer?: PublicAccount): Uint8Array {
         const signerBuffer = new Uint8Array(32);
         const signatureBuffer = new Uint8Array(64);
-
         let transactions = Uint8Array.from([]);
         this.innerTransactions.forEach((transaction) => {
+            if (!transaction.signer) {
+                if (this.type === TransactionType.AGGREGATE_COMPLETE) {
+                    transaction = Object.assign({__proto__: Object.getPrototypeOf(transaction)}, transaction, {signer});
+                } else {
+                    throw new Error(
+                        'InnerTransaction signer must be provide. Only AggregateComplete transaction can use delegated signer.');
+                }
+            }
             const transactionByte = transaction.toAggregateTransactionBytes();
             transactions = GeneratorUtils.concatTypedArrays(transactions, transactionByte);
         });

--- a/src/model/transaction/InnerTransaction.ts
+++ b/src/model/transaction/InnerTransaction.ts
@@ -20,4 +20,4 @@ import {Transaction} from './Transaction';
 /**
  * Transaction with signer included, used when adding signer to transactions included in an aggregate transaction.
  */
-export type InnerTransaction = Transaction &  {signer: PublicAccount};
+export type InnerTransaction = Transaction &  {signer?: PublicAccount};

--- a/src/service/AggregateTransactionService.ts
+++ b/src/service/AggregateTransactionService.ts
@@ -53,7 +53,7 @@ export class AggregateTransactionService {
             signers.push(signedTransaction.signerPublicKey);
         }
         return observableFrom(aggregateTransaction.innerTransactions).pipe(
-            mergeMap((innerTransaction) => this.accountHttp.getMultisigAccountInfo(innerTransaction.signer.address)
+            mergeMap((innerTransaction) => this.accountHttp.getMultisigAccountInfo(innerTransaction.signer!.address)
                 .pipe(
                     /**
                      * For multisig account, we need to get the graph info in case it has multiple levels


### PR DESCRIPTION
- Changed signer param to be optional on `toAggregate` when adding inner transactions. If not signer in inner transaction not provided, the main Aggregate transaction signer will be delegated.
- This change **ONLY** applies on **AggregateComplete** transaction
- Added validation if no signer (inner tx) provided in AggregateBond transaction
- Added tests