### PR TITLE
v0.14.1 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [0.14.1] - 14-Oct-2019
 
-**Milestone**: Fuschicho
+**Milestone**: Fushicho
 
 - Added `Receipt serializer & hash generator` for auditing receipt merkle proof.
 - Added `Unresolved (NamespaceId)` support on `MosaicRestriction` and `MosaicMetadata` transactions.
@@ -15,7 +15,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 
 ## [0.14.0] - 08-Oct-2019
 
-**Milestone**: Fuschicho
+**Milestone**: Fushicho
 
 - Added `KeyGenerator` class for generating UInt64 Keys from string.
 - Fixed `MosaicAmountView` issue. Now return observable of array.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.14.1] - 14-Oct-2019
+
+**Milestone**: Fuschicho
+
+- Added `Receipt serializer & hash generator` for auditing receipt merkle proof.
+- Added `Unresolved (NamespaceId)` support on `MosaicRestriction` and `MosaicMetadata` transactions.
+- Fixed `Mosaic array ordering` in `TransferTransaction`.
+- Fixed issues in `PersistentDelegationRequestTransaction`.
+- Other small fixes from community feedbacks.
+
 ## [0.14.0] - 08-Oct-2019
 
 **Milestone**: Fuschicho
@@ -222,6 +232,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.14.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.0...v0.14.1
 [0.14.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.4...v0.14.0
 [0.13.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.3...v0.13.4
 [0.13.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.13.2...v0.13.3

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the NEM2 (a.k.a Catapult)
 
 ### _Fuschicho_ Network Compatibility (catapult-server@0.8.0.3)
 
-Due to a network upgrade with [catapult-server@fuschicho](https://github.com/nemtech/catapult-server/releases/tag/v0.8.0.3) version, **it is recommended to use this package's 0.14.0 version and upwards to use this package with Fuschicho versioned networks**.
+Due to a network upgrade with [catapult-server@fuschicho](https://github.com/nemtech/catapult-server/releases/tag/v0.8.0.3) version, **it is recommended to use this package's 0.14.1 version and upwards to use this package with Fuschicho versioned networks**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
-### _Fuschicho_ Network Compatibility (catapult-server@0.8.0.3)
+### _Fushicho_ Network Compatibility (catapult-server@0.8.0.3)
 
-Due to a network upgrade with [catapult-server@fuschicho](https://github.com/nemtech/catapult-server/releases/tag/v0.8.0.3) version, **it is recommended to use this package's 0.14.1 version and upwards to use this package with Fuschicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.8.0.3) version, **it is recommended to use this package's 0.14.1 version and upwards to use this package with Fushicho versioned networks**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.14.0",
+  "version": "0.14.1",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
- Added `Receipt serializer & hash generator` for auditing receipt merkle proof.
- Added `Unresolved (NamespaceId)` support on `MosaicRestriction` and `MosaicMetadata` transactions.
- Fixed `Mosaic array ordering` in `TransferTransaction`.
- Fixed issues in `PersistentDelegationRequestTransaction`.
- Other small fixes from community feedbacks.