### PR TITLE
Fixed MosaicSupplyChangeTransaction schema issue (Direction -> Action)

### DIFF
--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -1148,7 +1148,7 @@ describe('TransactionHttp', () => {
             const signedTransaction = mosaicSupplyChangeTransaction.signWith(account, generationHash);
             listener.confirmed(account.address).subscribe((transaction: MosaicSupplyChangeTransaction) => {
                 expect(transaction.delta, 'Delta').not.to.be.undefined;
-                expect(transaction.direction, 'Direction').not.to.be.undefined;
+                expect(transaction.action, 'Action').not.to.be.undefined;
                 expect(transaction.mosaicId, 'MosaicId').not.to.be.undefined;
                 done();
             });

--- a/e2e/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
+++ b/e2e/infrastructure/transaction/CreateTransactionFromDTO.spec.ts
@@ -423,7 +423,7 @@ describe('CreateTransactionFromDTO', () => {
                 transaction: {
                     deadline: '1',
                     delta: '1000',
-                    direction: 1,
+                    action: 1,
                     maxFee: '0',
                     mosaicId: '85BBEA6CC462B244',
                     signature: '553E696EB4A54E43A11D180EBA57E4B89D0048C9DD2604A9E0608120018B9E0' +
@@ -472,7 +472,7 @@ describe('CreateTransactionFromDTO', () => {
                             },
                             transaction: {
                                 delta: '1000',
-                                direction: 1,
+                                action: 1,
                                 mosaicId: '85BBEA6CC462B244',
                                 signerPublicKey: 'B4F12E7C9F6946091E2CB8B6D3A12B50D17CCBBF646386EA27CE2946A7423DCF',
                                 type: 16973,

--- a/e2e/infrastructure/transaction/ValidateTransaction.ts
+++ b/e2e/infrastructure/transaction/ValidateTransaction.ts
@@ -112,8 +112,8 @@ const ValidateTransaction = {
     validateMosaicSupplyChangeTx: (mosaicSupplyChangeTransaction, mosaicSupplyChangeTransactionDTO) => {
         deepEqual(mosaicSupplyChangeTransaction.mosaicId,
             new MosaicId(mosaicSupplyChangeTransactionDTO.transaction.mosaicId));
-        expect(mosaicSupplyChangeTransaction.direction)
-            .to.be.equal(mosaicSupplyChangeTransactionDTO.transaction.direction);
+        expect(mosaicSupplyChangeTransaction.action)
+            .to.be.equal(mosaicSupplyChangeTransactionDTO.transaction.action);
         deepEqual(mosaicSupplyChangeTransaction.delta,
             UInt64.fromNumericString(mosaicSupplyChangeTransactionDTO.transaction.delta));
     },

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -178,7 +178,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
             Deadline.createFromDTO(transactionDTO.deadline),
             UInt64.fromNumericString(transactionDTO.maxFee || '0'),
             new MosaicId(transactionDTO.mosaicId),
-            transactionDTO.direction,
+            transactionDTO.action,
             UInt64.fromNumericString(transactionDTO.delta),
             transactionDTO.signature,
             transactionDTO.signerPublicKey ? PublicAccount.createFromPublicKey(transactionDTO.signerPublicKey,

--- a/src/infrastructure/transaction/SerializeTransactionToJSON.ts
+++ b/src/infrastructure/transaction/SerializeTransactionToJSON.ts
@@ -122,7 +122,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
         case TransactionType.MOSAIC_SUPPLY_CHANGE:
             return {
                 mosaicId: (transaction as MosaicSupplyChangeTransaction).mosaicId.toHex(),
-                direction: (transaction as MosaicSupplyChangeTransaction).direction,
+                action: (transaction as MosaicSupplyChangeTransaction).action,
                 delta: (transaction as MosaicSupplyChangeTransaction).delta.toString(),
             };
         case TransactionType.REGISTER_NAMESPACE:

--- a/src/model/transaction/MosaicSupplyChangeTransaction.ts
+++ b/src/model/transaction/MosaicSupplyChangeTransaction.ts
@@ -44,7 +44,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      * Create a mosaic supply change transaction object
      * @param deadline - The deadline to include the transaction.
      * @param mosaicId - The mosaic id.
-     * @param direction - The supply type.
+     * @param action - The supply change action (increase | decrease).
      * @param delta - The supply change in units for the mosaic.
      * @param networkType - The network type.
      * @param maxFee - (Optional) Max fee defined by the sender
@@ -52,7 +52,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      */
     public static create(deadline: Deadline,
                          mosaicId: MosaicId,
-                         direction: MosaicSupplyChangeAction,
+                         action: MosaicSupplyChangeAction,
                          delta: UInt64,
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): MosaicSupplyChangeTransaction {
@@ -61,7 +61,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
             deadline,
             maxFee,
             mosaicId,
-            direction,
+            action,
             delta,
         );
     }
@@ -72,7 +72,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
      * @param deadline
      * @param maxFee
      * @param mosaicId
-     * @param direction
+     * @param action
      * @param delta
      * @param signature
      * @param signer
@@ -89,7 +89,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
                 /**
                  * The supply type.
                  */
-                public readonly direction: MosaicSupplyChangeAction,
+                public readonly action: MosaicSupplyChangeAction,
                 /**
                  * The supply change in units for the mosaic.
                  */
@@ -136,10 +136,10 @@ export class MosaicSupplyChangeTransaction extends Transaction {
 
         // set static byte size fields
         const byteMosaicId = 8;
-        const byteDirection = 1;
+        const byteAction = 1;
         const byteDelta = 8;
 
-        return byteSize + byteMosaicId + byteDirection + byteDelta;
+        return byteSize + byteMosaicId + byteAction + byteDelta;
     }
 
     /**
@@ -158,7 +158,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new UnresolvedMosaicIdDto(this.mosaicId.id.toDTO()),
-            this.direction.valueOf(),
+            this.action.valueOf(),
             new AmountDto(this.delta.toDTO()),
         );
         return transactionBuilder.serialize();
@@ -174,7 +174,7 @@ export class MosaicSupplyChangeTransaction extends Transaction {
             this.versionToDTO(),
             TransactionType.MOSAIC_SUPPLY_CHANGE.valueOf(),
             new UnresolvedMosaicIdDto(this.mosaicId.id.toDTO()),
-            this.direction.valueOf(),
+            this.action.valueOf(),
             new AmountDto(this.delta.toDTO()),
         );
         return transactionBuilder.serialize();

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -311,7 +311,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
         const transaction = TransactionMapping.createFromPayload(signedTransaction.payload) as MosaicSupplyChangeTransaction;
 
-        expect(transaction.direction).to.be.equal(MosaicSupplyChangeAction.Increase);
+        expect(transaction.action).to.be.equal(MosaicSupplyChangeAction.Increase);
         expect(transaction.delta.lower).to.be.equal(10);
         expect(transaction.delta.higher).to.be.equal(0);
         expect(transaction.mosaicId.id.lower).to.be.equal(2262289484);
@@ -877,7 +877,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
             TransactionMapping.createFromDTO(mosaicSupplyChangeTransaction.toJSON()) as MosaicSupplyChangeTransaction;
 
         expect(transaction.type).to.be.equal(TransactionType.MOSAIC_SUPPLY_CHANGE);
-        expect(transaction.direction).to.be.equal(MosaicSupplyChangeAction.Increase);
+        expect(transaction.action).to.be.equal(MosaicSupplyChangeAction.Increase);
 
     });
 

--- a/test/infrastructure/SerializeTransactionToJSON.spec.ts
+++ b/test/infrastructure/SerializeTransactionToJSON.spec.ts
@@ -18,8 +18,6 @@ import { expect } from 'chai';
 import { sha3_256 } from 'js-sha3';
 import {Convert as convert} from '../../src/core/format';
 import { Account } from '../../src/model/account/Account';
-import { AccountRestrictionModificationAction } from '../../src/model/restriction/AccountRestrictionModificationAction';
-import { AccountRestrictionType } from '../../src/model/restriction/AccountRestrictionType';
 import { Address } from '../../src/model/account/Address';
 import { PublicAccount } from '../../src/model/account/PublicAccount';
 import { NetworkType } from '../../src/model/blockchain/NetworkType';
@@ -31,6 +29,8 @@ import { MosaicSupplyChangeAction } from '../../src/model/mosaic/MosaicSupplyCha
 import { NetworkCurrencyMosaic } from '../../src/model/mosaic/NetworkCurrencyMosaic';
 import { AliasAction } from '../../src/model/namespace/AliasAction';
 import { NamespaceId } from '../../src/model/namespace/NamespaceId';
+import { AccountRestrictionModificationAction } from '../../src/model/restriction/AccountRestrictionModificationAction';
+import { AccountRestrictionType } from '../../src/model/restriction/AccountRestrictionType';
 import { AccountLinkTransaction } from '../../src/model/transaction/AccountLinkTransaction';
 import { AccountRestrictionModification } from '../../src/model/transaction/AccountRestrictionModification';
 import { AccountRestrictionTransaction } from '../../src/model/transaction/AccountRestrictionTransaction';
@@ -221,7 +221,7 @@ describe('SerializeTransactionToJSON', () => {
         const json = mosaicSupplyChangeTransaction.toJSON();
 
         expect(json.transaction.type).to.be.equal(TransactionType.MOSAIC_SUPPLY_CHANGE);
-        expect(json.transaction.direction).to.be.equal(MosaicSupplyChangeAction.Increase);
+        expect(json.transaction.action).to.be.equal(MosaicSupplyChangeAction.Increase);
 
     });
 

--- a/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
+++ b/test/model/transaction/MosaicSupplyChangeTransaction.spec.ts
@@ -20,7 +20,7 @@ import {NetworkType} from '../../../src/model/blockchain/NetworkType';
 import {MosaicId} from '../../../src/model/mosaic/MosaicId';
 import {MosaicSupplyChangeAction} from '../../../src/model/mosaic/MosaicSupplyChangeAction';
 import {Deadline} from '../../../src/model/transaction/Deadline';
-import {MosaicSupplyChangeTransaction,} from '../../../src/model/transaction/MosaicSupplyChangeTransaction';
+import {MosaicSupplyChangeTransaction} from '../../../src/model/transaction/MosaicSupplyChangeTransaction';
 import {UInt64} from '../../../src/model/UInt64';
 import {TestingAccount} from '../../conf/conf.spec';
 
@@ -53,7 +53,7 @@ describe('MosaicSupplyChangeTransaction', () => {
             MosaicSupplyChangeAction.Increase,
             UInt64.fromUint(10),
             NetworkType.MIJIN_TEST,
-            new UInt64([1, 0])
+            new UInt64([1, 0]),
         );
 
         expect(mosaicSupplyChangeTransaction.maxFee.higher).to.be.equal(0);
@@ -70,7 +70,7 @@ describe('MosaicSupplyChangeTransaction', () => {
             NetworkType.MIJIN_TEST,
         );
 
-        expect(mosaicSupplyChangeTransaction.direction).to.be.equal(MosaicSupplyChangeAction.Increase);
+        expect(mosaicSupplyChangeTransaction.action).to.be.equal(MosaicSupplyChangeAction.Increase);
         expect(mosaicSupplyChangeTransaction.delta.lower).to.be.equal(10);
         expect(mosaicSupplyChangeTransaction.delta.higher).to.be.equal(0);
         expect(mosaicSupplyChangeTransaction.mosaicId.id.lower).to.be.equal(2262289484);


### PR DESCRIPTION
- Fixed MosaicSupplyChangeTransaction still uses old schema field `Direction` issue. Replaced to `Action`

Issue: #309 