### PR TITLE
#345: add method addCosignatures to fill cosignatures offline

### DIFF
--- a/src/model/transaction/AggregateTransaction.ts
+++ b/src/model/transaction/AggregateTransaction.ts
@@ -195,6 +195,17 @@ export class AggregateTransaction extends Transaction {
     }
 
     /**
+     * @description add cosignatures to current list
+     * @param {AggregateTransactionCosignature[]} transaction
+     * @returns {AggregateTransaction}
+     * @memberof AggregateTransaction
+     */
+    public addCosignatures(cosigs: AggregateTransactionCosignature[]): AggregateTransaction {
+        const cosignatures = this.cosignatures.concat(cosigs);
+        return Object.assign({__proto__: Object.getPrototypeOf(this)}, this, {cosignatures});
+    }
+
+    /**
      * @internal
      * Sign transaction with cosignatories creating a new SignedTransaction
      * @param initiatorAccount - Initiator account


### PR DESCRIPTION
- Added `AggregateTransaction.addCosignatures` method
- Added unit test to fill cosignatures after object creation