### PR TITLE
v0.15.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.15.1] - 06-Dec-2019
+
+**Milestone**: Fushicho.2
+
+- Added `networkType` as an optional paramter in `Http` abstract to recude the number of requests to the catapult-rest server
+- Added `resolveAlias` in transaction for resolving `UnresolvedAddress` and `UnresolvedMosaic` inside a transaction.
+- Added `TransactionService` class.
+- Added `resolveAlias` service in `TransactionService` which resolves alias(es) in transaction(s) from block `ResolutionStatement`.
+- Consolicated transaction announcement and websocket `confirmed` listener into one service call in `TransactionService`.
+- Consolidated `AggregateBonded` tranaction announcement (aggregateBonded + lockFund) into one service call in `TransactionService`.
+
 ## [0.15.0] - 21-Nov-2019
 
 **Milestone**: Fushicho.2
@@ -266,6 +277,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.15.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.4...v0.15.0
 [0.14.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.2...v0.14.3

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ with the NEM2 (a.k.a Catapult)
 
 ### _Fushicho_ Network Compatibility (catapult-server@0.9.0.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.0.1) version, **it is recommended to use this package's 0.15.0 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.0.1) version, **it is recommended to use this package's 0.15.1 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.15.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.15.0) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.15.1](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.15.1) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
## [0.15.1] - 06-Dec-2019

**Milestone**: Fushicho.2

- Added `networkType` as an optional paramter in `Http` abstract to recude the number of requests to the catapult-rest server
- Added `resolveAlias` in transaction for resolving `UnresolvedAddress` and `UnresolvedMosaic` inside a transaction.
- Added `TransactionService` class.
- Added `resolveAlias` service in `TransactionService` which resolves alias(es) in transaction(s) from block `ResolutionStatement`.
- Consolicated transaction announcement and websocket `confirmed` listener into one service call in `TransactionService`.
- Consolidated `AggregateBonded` tranaction announcement (aggregateBonded + lockFund) into one service call in `TransactionService`.
