### PR TITLE
v0.16.0 release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,8 @@ cache:
     - "node_modules"
 script:
   - npm run build
-after_success: 
-  - npm run test:coveralls
+# script: 
+#   - npm run test:coveralls
 before_deploy:
   - npm install --global typedoc
   - typedoc --out ts-docs src

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,10 +6,10 @@ node_js:
 cache:
   directories:
     - "node_modules"
-script:
+before_script:
   - npm run build
-# script: 
-#   - npm run test:coveralls
+script: 
+  - npm run test:coveralls
 before_deploy:
   - npm install --global typedoc
   - typedoc --out ts-docs src

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,9 @@ node_js:
 cache:
   directories:
     - "node_modules"
-before_script:
+script:
   - npm run build
-script: 
+after_success: 
   - npm run test:coveralls
 before_deploy:
   - npm install --global typedoc

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,8 @@ cache:
 before_script:
   - npm run build
 script: 
-  - npm run test:coveralls
-before_deploy:
+  - npm run test:cov
+  - npm run coveralls-report
   - npm install --global typedoc
   - typedoc --out ts-docs src
   - touch ./ts-docs/.nojekyll

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [0.16.0] - 09-Dec-2019
+
+**Milestone**: Fushicho.3
+
+- Added epochAdjustment introduced in catapult-server v0.9.1.1 (Fushicho.3)
+- Added `setMaxFee` to `Transaction` which calculate max transaction fee using `feeMultiplier * transaction.size`.
+- Optimised `resolveAlias` implementation in transaction using object spread operator.
+- Fixed couple of bugs in `blockHttp` and unit tests
+
 ## [0.15.1] - 06-Dec-2019
 
 **Milestone**: Fushicho.2
@@ -277,6 +286,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.16.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.4...v0.15.0
 [0.14.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.14.3...v0.14.4

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
-### _Fushicho_ Network Compatibility (catapult-server@0.9.0.1)
+### _Fushicho_ Network Compatibility (catapult-server@0.9.1.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.0.1) version, **it is recommended to use this package's 0.15.1 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.0 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.15.1](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.15.1) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.16.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.0) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
   "nyc": {
     "exclude-after-remap": false,
     "exclude": [
+      "**/*.spec.js",
       "gulpfile.js"
     ]
   }

--- a/package.json
+++ b/package.json
@@ -77,8 +77,10 @@
     "rxjs": "^6.2.1"
   },
   "nyc": {
+    "exclude-after-remap": false,
     "exclude": [
-      "**/*.spec.js"
+      "**/*.spec.js",
+      "gulpfile.js"
     ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.15.1",
+  "version": "0.16.0",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "test:all": "mocha --ui bdd --recursive ./dist/ --timeout 90000",
     "build": "rm -rf dist/ && tsc && npm run e2econfigcopy",
     "test:cov": "nyc --reporter=lcov --reporter=text-lcov npm t && nyc report --reporter=text-lcov",
-    "test:coveralls": "npm run test:cov | coveralls"
+    "test:coveralls": "npm run test:cov | coveralls",
+    "coveralls-report": "cat ./coverage/lcov.info | coveralls"
   },
   "contributors": [
     {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test:e2e": "npm run build && mocha --ui bdd --recursive ./dist/e2e --timeout 90000",
     "test:all": "mocha --ui bdd --recursive ./dist/ --timeout 90000",
     "build": "rm -rf dist/ && tsc && npm run e2econfigcopy",
-    "test:cov": "nyc --reporter=lcov --reporter=text-lcov npm t && nyc report --reporter=text-lcov",
+    "test:cov": "nyc --reporter=lcov --reporter=text-summary npm t",
     "test:coveralls": "npm run test:cov | coveralls",
     "coveralls-report": "cat ./coverage/lcov.info | coveralls"
   },

--- a/package.json
+++ b/package.json
@@ -79,7 +79,6 @@
   "nyc": {
     "exclude-after-remap": false,
     "exclude": [
-      "**/*.spec.js",
       "gulpfile.js"
     ]
   }

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -406,7 +406,7 @@ describe('TransferTransaction', () => {
             NetworkType.MIJIN_TEST,
         ).setMaxFee(2);
 ​
-        expect(transferTransaction.maxFee.compact()).to.be.equal(378);
+        expect(transferTransaction.maxFee.compact()).to.be.equal(0);
     });
 
     it('Test resolveAlias can resolve', () => {

--- a/test/model/transaction/TransferTransaction.spec.ts
+++ b/test/model/transaction/TransferTransaction.spec.ts
@@ -406,7 +406,7 @@ describe('TransferTransaction', () => {
             NetworkType.MIJIN_TEST,
         ).setMaxFee(2);
 ​
-        expect(transferTransaction.maxFee.compact()).to.be.equal(0);
+        expect(transferTransaction.maxFee.compact()).to.be.equal(378);
     });
 
     it('Test resolveAlias can resolve', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,6 +12,7 @@
     "stripInternal": true,
     "outDir": "dist",
     "allowJs": false,
+    "skipLibCheck": true,
     "lib": [
       "es2017",
       "dom"


### PR DESCRIPTION
## [0.16.0] - 09-Dec-2019

**Milestone**: Fushicho.3

- Added epochAdjustment introduced in catapult-server v0.9.1.1 (Fushicho.3)
- Added `setMaxFee` to `Transaction` which calculate max transaction fee using `feeMultiplier * transaction.size`.
- Optimised `resolveAlias` implementation in transaction using object spread operator.
- Fixed couple of bugs in `blockHttp` and unit tests
- Fixed travis-CI issue
- Fixed `coveralls` always return 100% issue
