### PR TITLE
Fixed listener status bug and make MultisigAccountGraphInfo constructor public

### DIFF
--- a/e2e/infrastructure/BlockHttp.spec.ts
+++ b/e2e/infrastructure/BlockHttp.spec.ts
@@ -80,7 +80,7 @@ describe('BlockHttp', () => {
             const signedTransaction = transferTransaction.signWith(account, generationHash);
             helper.announce(signedTransaction).then((transaction) => {
                 chainHeight = transaction.transactionInfo!.height.toString();
-                return transaction;
+                done();
             });
         });
     });

--- a/e2e/infrastructure/IntegrationTestHelper.ts
+++ b/e2e/infrastructure/IntegrationTestHelper.ts
@@ -77,8 +77,7 @@ export class IntegrationTestHelper {
                                 '../../../catapult-service-bootstrap/build/generated-addresses/addresses.yaml'),
                                     (error: any, yamlData: any) => {
                             if (error) {
-                                console.log(`catapult-service-bootstrap generated address could not be loaded.
-                                    Ignoring and using accounts from network.conf. Error: ${error}`);
+                                console.log(`catapult-service-bootstrap generated address could not be loaded. Ignoring and using accounts from network.conf.`);
                                 return resolve(this);
                             } else {
                                 const parsedYaml = this.yaml.safeLoad(yamlData);

--- a/e2e/infrastructure/Listener.spec.ts
+++ b/e2e/infrastructure/Listener.spec.ts
@@ -369,7 +369,7 @@ describe('Listener', () => {
             return helper.announce(transferTransaction.signWith(account, generationHash)).then(() => {
                 throw new Error('Transaction should have failed!!');
             }, (error) => {
-                expect(error.status).to.be.equal('Failure_Core_Insufficient_Balance');
+                expect(error.code).to.be.equal('Failure_Core_Insufficient_Balance');
             });
         });
     });

--- a/src/infrastructure/Listener.ts
+++ b/src/infrastructure/Listener.ts
@@ -160,12 +160,12 @@ export class Listener implements IListener {
                     extractBeneficiary(message, message.block.network), // passing `message` as `blockDTO`
                 ),
             });
-        } else if (message.status) {
+        } else if (message.code) {
             this.messageSubject.next({
                 channelName: ListenerChannelName.status, message: new TransactionStatusError(
                     Address.createFromEncoded(message.address),
                     message.hash,
-                    message.status,
+                    message.code,
                     Deadline.createFromDTO(message.deadline)),
             });
         } else if (message.parentHash) {

--- a/src/model/account/MultisigAccountGraphInfo.ts
+++ b/src/model/account/MultisigAccountGraphInfo.ts
@@ -22,7 +22,6 @@ import {MultisigAccountInfo} from './MultisigAccountInfo';
 export class MultisigAccountGraphInfo {
 
     /**
-     * @internal
      * @param multisigAccounts
      */
     constructor(/**

--- a/src/model/transaction/TransactionStatusError.ts
+++ b/src/model/transaction/TransactionStatusError.ts
@@ -26,7 +26,7 @@ export class TransactionStatusError {
      * @internal
      * @param address
      * @param hash
-     * @param status
+     * @param code
      * @param deadline
      */
     constructor(
@@ -40,9 +40,9 @@ export class TransactionStatusError {
                  */
                 public readonly hash: string,
                 /**
-                 * The status error message.
+                 * The error code.
                  */
-                public readonly status: string,
+                public readonly code: string,
                 /**
                  * The transaction deadline.
                  */

--- a/test/infrastructure/Listener.spec.ts
+++ b/test/infrastructure/Listener.spec.ts
@@ -56,7 +56,7 @@ describe('Listener', () => {
                 address: errorEncodedAddress,
                 deadline: '1010',
                 hash: 'transaction-hash',
-                status: 'error-message',
+                code: 'error-message',
             };
 
             const listener = new Listener('ws://localhost:3000', WebSocketMock);
@@ -75,7 +75,7 @@ describe('Listener', () => {
             const transactionStatusError = reportedStatus[0];
             expect(transactionStatusError.address).to.deep.equal(errorAddress);
             expect(transactionStatusError.hash).to.be.equal(statusInfoErrorDTO.hash);
-            expect(transactionStatusError.status).to.be.equal(statusInfoErrorDTO.status);
+            expect(transactionStatusError.code).to.be.equal(statusInfoErrorDTO.code);
             deepEqual(transactionStatusError.deadline.toDTO(), UInt64.fromNumericString(statusInfoErrorDTO.deadline).toDTO());
 
         });

--- a/test/model/transaction/TransactionStatusError.spec.ts
+++ b/test/model/transaction/TransactionStatusError.spec.ts
@@ -28,17 +28,17 @@ describe('TransactionStatusError', () => {
             address: Address.createFromRawAddress('SBILTA367K2LX2FEXG5TFWAS7GEFYAGY7QLFBYKC'),
             deadline: '1010',
             hash: 'transaction-hash',
-            status: 'error-message',
+            code: 'error-message',
         };
         const transactionStatusError = new TransactionStatusError(
             statusInfoErrorDTO.address,
             statusInfoErrorDTO.hash,
-            statusInfoErrorDTO.status,
+            statusInfoErrorDTO.code,
             Deadline.createFromDTO(statusInfoErrorDTO.deadline));
 
         expect(transactionStatusError.address).to.be.equal(statusInfoErrorDTO.address);
         expect(transactionStatusError.hash).to.be.equal(statusInfoErrorDTO.hash);
-        expect(transactionStatusError.status).to.be.equal(statusInfoErrorDTO.status);
+        expect(transactionStatusError.code).to.be.equal(statusInfoErrorDTO.code);
         deepEqual(transactionStatusError.deadline.toDTO(), UInt64.fromNumericString(statusInfoErrorDTO.deadline).toDTO());
     });
 });


### PR DESCRIPTION
Fixed #411 #410 

- Fixed transaction status issue due to `Status` has been renamed to `code` in `Catapult-rest`.
- Fixed a blockHttp integration test time out bug
- Removed internal from MultisigAccountGraphInfo
