### PR TITLE
Allow unresolved in mosaic restriction transaction

### DIFF
--- a/src/model/transaction/MosaicAddressRestrictionTransaction.ts
+++ b/src/model/transaction/MosaicAddressRestrictionTransaction.ts
@@ -23,7 +23,7 @@ import {
     SignatureDto,
     TimestampDto,
     UnresolvedAddressDto,
-    UnresolvedMosaicIdDto
+    UnresolvedMosaicIdDto,
 } from 'catbuffer';
 import { Convert } from '../../core/format';
 import { DtoMapping } from '../../core/utils/DtoMapping';

--- a/test/service/MosaicRestrictionTransactionservice.spec.ts
+++ b/test/service/MosaicRestrictionTransactionservice.spec.ts
@@ -18,10 +18,12 @@ import { expect } from 'chai';
 import { of as observableOf } from 'rxjs';
 import { deepEqual, instance, mock, when } from 'ts-mockito';
 import { KeyGenerator } from '../../src/core/format/KeyGenerator';
+import { NamespaceRepository } from '../../src/infrastructure/NamespaceRepository';
 import { RestrictionMosaicRepository } from '../../src/infrastructure/RestrictionMosaicRepository';
 import { Account } from '../../src/model/account/Account';
 import { NetworkType } from '../../src/model/blockchain/NetworkType';
 import { MosaicId } from '../../src/model/mosaic/MosaicId';
+import { NamespaceId } from '../../src/model/namespace/NamespaceId';
 import { MosaicAddressRestriction } from '../../src/model/restriction/MosaicAddressRestriction';
 import { MosaicGlobalRestriction } from '../../src/model/restriction/MosaicGlobalRestriction';
 import { MosaicGlobalRestrictionItem } from '../../src/model/restriction/MosaicGlobalRestrictionItem';
@@ -38,6 +40,8 @@ import { TestingAccount } from '../conf/conf.spec';
 describe('MosaicRestrictionTransactionService', () => {
     let account: Account;
     let mosaicId: MosaicId;
+    let unresolvedMosaicId: NamespaceId;
+    let unresolvedAddress: NamespaceId;
     let referenceMosaicId: MosaicId;
     let mosaicRestrictionTransactionService: MosaicRestrictionTransactionService;
     const key = KeyGenerator.generateUInt64Key('TestKey');
@@ -50,21 +54,33 @@ describe('MosaicRestrictionTransactionService', () => {
     before(() => {
         account = TestingAccount;
         mosaicId = new MosaicId('85BBEA6CC462B244');
+        unresolvedMosaicId = NamespaceId.createFromEncoded('F8495AEE892FA108');
+        unresolvedAddress = NamespaceId.createFromEncoded('AB114281960BF1CC');
         mosaicIdWrongKey = new MosaicId('85BBEA6CC462B288');
         referenceMosaicId = new MosaicId('1AB129B545561E6A');
         const mockRestrictionRepository = mock<RestrictionMosaicRepository>();
+        const mockNamespaceRepository = mock<NamespaceRepository>();
 
         when(mockRestrictionRepository
             .getMosaicGlobalRestriction(deepEqual(mosaicId)))
             .thenReturn(observableOf(mockGlobalRestriction()));
         when(mockRestrictionRepository
             .getMosaicGlobalRestriction(deepEqual(mosaicIdWrongKey)))
-            .thenThrow(new Error());
+            .thenThrow(new Error('Wrong mosaicId'));
         when(mockRestrictionRepository
             .getMosaicAddressRestriction(deepEqual(mosaicId), deepEqual(account.address)))
                 .thenReturn(observableOf(mockAddressRestriction()));
+        when(mockNamespaceRepository.getLinkedMosaicId(deepEqual(unresolvedMosaicId)))
+            .thenReturn(observableOf(mosaicId));
+        when(mockNamespaceRepository.getLinkedMosaicId(deepEqual(unresolvedAddress)))
+            .thenThrow(new Error('invalid namespaceId'));
+        when(mockNamespaceRepository.getLinkedAddress(deepEqual(unresolvedAddress)))
+            .thenReturn(observableOf(account.address));
+        when(mockNamespaceRepository.getLinkedAddress(deepEqual(unresolvedMosaicId)))
+            .thenThrow(new Error('invalid namespaceId'));
         const restrictionRepository = instance(mockRestrictionRepository);
-        mosaicRestrictionTransactionService = new MosaicRestrictionTransactionService(restrictionRepository);
+        const namespaceRepository = instance(mockNamespaceRepository);
+        mosaicRestrictionTransactionService = new MosaicRestrictionTransactionService(restrictionRepository, namespaceRepository);
     });
 
     it('should create MosaicGlobalRestriction Transaction', (done) => {
@@ -77,7 +93,7 @@ describe('MosaicRestrictionTransactionService', () => {
                                             MosaicRestrictionType.LE)
             .subscribe((transaction: MosaicGlobalRestrictionTransaction) => {
                 expect(transaction.type).to.be.equal(TransactionType.MOSAIC_GLOBAL_RESTRICTION);
-                expect(transaction.restrictionKey.toHex()).to.be.equal(key.toHex());
+                expect(transaction.restrictionKey.toString()).to.be.equal(key.toString());
                 expect(transaction.previousRestrictionType).to.be.equal(globalRestrictionType);
                 expect(transaction.previousRestrictionValue.toString()).to.be.equal(globalRestrictionValue);
                 expect(transaction.referenceMosaicId.toHex()).to.be.equal(new MosaicId(UInt64.fromUint(0).toDTO()).toHex());
@@ -114,11 +130,70 @@ describe('MosaicRestrictionTransactionService', () => {
                                             '2000')
             .subscribe((transaction: MosaicAddressRestrictionTransaction) => {
                 expect(transaction.type).to.be.equal(TransactionType.MOSAIC_ADDRESS_RESTRICTION);
-                expect(transaction.restrictionKey.toHex()).to.be.equal(key.toHex());
+                expect(transaction.restrictionKey.toString()).to.be.equal(key.toString());
                 expect(transaction.targetAddressToString()).to.be.equal(account.address.plain());
                 expect(transaction.previousRestrictionValue.toString()).to.be.equal(addressRestrictionValue);
                 done();
         });
+    });
+
+    it('should create MosaicGlobalRestriction Transaction with unresolvedMosaicId', (done) => {
+        mosaicRestrictionTransactionService.createMosaicGlobalRestrictionTransaction(
+                                            Deadline.create(),
+                                            NetworkType.MIJIN_TEST,
+                                            unresolvedMosaicId,
+                                            key,
+                                            '2000',
+                                            MosaicRestrictionType.LE)
+            .subscribe((transaction: MosaicGlobalRestrictionTransaction) => {
+                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_GLOBAL_RESTRICTION);
+                expect(transaction.restrictionKey.toHex()).to.be.equal(key.toHex());
+                expect(transaction.previousRestrictionType).to.be.equal(globalRestrictionType);
+                expect(transaction.previousRestrictionValue.toString()).to.be.equal(globalRestrictionValue);
+                expect(transaction.referenceMosaicId.toHex()).to.be.equal(new MosaicId(UInt64.fromUint(0).toDTO()).toHex());
+                done();
+        });
+    });
+
+    it('should create MosaicAddressRestriction Transaction with unresolvedAddress', (done) => {
+        mosaicRestrictionTransactionService.createMosaicAddressRestrictionTransaction(
+                                            Deadline.create(),
+                                            NetworkType.MIJIN_TEST,
+                                            unresolvedMosaicId,
+                                            key,
+                                            unresolvedAddress,
+                                            '2000')
+            .subscribe((transaction: MosaicAddressRestrictionTransaction) => {
+                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_ADDRESS_RESTRICTION);
+                expect(transaction.restrictionKey.toString()).to.be.equal(key.toString());
+                expect(transaction.targetAddressToString()).to.be.equal(unresolvedAddress.toHex());
+                expect(transaction.previousRestrictionValue.toString()).to.be.equal(addressRestrictionValue);
+                done();
+        });
+    });
+
+    it('should throw error with invalid unresolvedMosaicId', () => {
+        expect(() => {
+            mosaicRestrictionTransactionService.createMosaicGlobalRestrictionTransaction(
+                Deadline.create(),
+                NetworkType.MIJIN_TEST,
+                unresolvedAddress,
+                key,
+                '2000',
+                MosaicRestrictionType.LE);
+        }).to.throw();
+    });
+
+    it('should throw error with invalid unresolvedAddress', () => {
+        expect(() => {
+            mosaicRestrictionTransactionService.createMosaicAddressRestrictionTransaction(
+                Deadline.create(),
+                NetworkType.MIJIN_TEST,
+                mosaicId,
+                key,
+                unresolvedMosaicId,
+                '2000');
+        }).to.throw();
     });
 
     it('should throw error with invalid value / key', () => {
@@ -143,16 +218,16 @@ describe('MosaicRestrictionTransactionService', () => {
         }).to.throw(Error, 'RestrictionValue: wrong value is not a valid numeric string.');
     });
 
-    it('should throw error with invalid global restriction key - MosaicAddressRestriction', () => {
-        expect(() => {
-            mosaicRestrictionTransactionService.createMosaicAddressRestrictionTransaction(
-                                                Deadline.create(),
-                                                NetworkType.MIJIN_TEST,
-                                                mosaicIdWrongKey,
-                                                invalidKey,
-                                                account.address,
-                                                '2000');
-        }).to.throw();
+    it('should throw error with invalid address restriction key - MosaicAddressRestriction', () => {
+        mosaicRestrictionTransactionService.createMosaicAddressRestrictionTransaction(
+            Deadline.create(),
+            NetworkType.MIJIN_TEST,
+            mosaicIdWrongKey,
+            invalidKey,
+            account.address,
+            '2000').subscribe((t) => {}, (err) => {
+                expect(err).not.to.be.undefined;
+            });
     });
 
     function mockGlobalRestriction(): MosaicGlobalRestriction {
@@ -161,7 +236,7 @@ describe('MosaicRestrictionTransactionService', () => {
             MosaicRestrictionEntryType.GLOBAL,
             mosaicId,
             new Map<string, MosaicGlobalRestrictionItem>()
-                .set(key.toHex(),
+                .set(key.toString(),
                     new MosaicGlobalRestrictionItem(
                         referenceMosaicId,
                         globalRestrictionValue,
@@ -178,7 +253,7 @@ describe('MosaicRestrictionTransactionService', () => {
             mosaicId,
             account.address,
             new Map<string, string>()
-                .set(key.toHex(),
+                .set(key.toString(),
                     addressRestrictionValue,
                 ),
         );


### PR DESCRIPTION
- Allow unresolved in mosaic restriction
- Fixed restrictionKey format bug due to `restrictionKey` changed from `hex` to `numericString`

Fixed #403 