### PR TITLE
v0.16.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 ## 06-Jan-2020
 
 **Milestone**: Fushicho.3
-| Versions  |   |   |
-|---|---|---|
-| SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk |
-| Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer |
-| Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client |
+ Versions  |   |
+---|---|---
+SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk 
+Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer 
+Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client 
 
 - Refactored to replace generated codes by public library package for both `Catbuffer` and `OpenAPI Http Client`.
 - Added unresolved (mosaicId, address) support in `MosaicRestrictionTransaction`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 06-Jan-2020
+
+**Milestone**: Fushicho.3
+| Versions  |   |   |
+|---|---|---|
+| SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk |
+| Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer |
+| Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client |
+
+- Refactored to replace generated codes by public library package for both `Catbuffer` and `OpenAPI Http Client`.
+- Added unresolved (mosaicId, address) support in `MosaicRestrictionTransaction`.
+- Added `toHex()` in `MosaicNonce` class.
+- Exposed `MultisigAccountGraphInfo` class constructor to public.
+- Fixed `transaction status` issue in both `Http` and `Websocket` due to schema update.
+
 ## [0.16.1] - 23-Dec-2019
 
 **Milestone**: Fushicho.3
@@ -302,6 +317,7 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.0...v0.15.1

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ with the NEM2 (a.k.a Catapult)
 
 ### _Fushicho_ Network Compatibility (catapult-server@0.9.1.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.1 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.2 version and upwards to use this package with Fushicho versioned networks**.
 
 The upgrade to this package's [version v0.16.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.0) is mandatory for **fushicho compatibility**.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -959,9 +959,9 @@
       "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "catbuffer": {
-      "version": "0.0.6-SNAPSHOT",
-      "resolved": "https://registry.npmjs.org/catbuffer/-/catbuffer-0.0.6-SNAPSHOT.tgz",
-      "integrity": "sha512-ipok0XX035s4kMMa/3317u5JzTaE1qS61ZkyB8YMJp/UizGQ7GawwExImDKYp5obzmIw/k5Q/lgrp9UJ0YJuOA=="
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/catbuffer/-/catbuffer-0.0.7.tgz",
+      "integrity": "sha512-c7oYz0Zhxa9Sw4Nzi8idIMdMyRvZ57SzzshyZKfqTQ0TCz2LyGHLD9X5/hg5P1ZqA5EARUF7kDKoL4IoBQ6IBQ=="
     },
     "chai": {
       "version": "4.1.2",
@@ -3818,9 +3818,9 @@
       }
     },
     "nem2-sdk-openapi-typescript-node-client": {
-      "version": "0.7.2-0.6.1",
-      "resolved": "https://registry.npmjs.org/nem2-sdk-openapi-typescript-node-client/-/nem2-sdk-openapi-typescript-node-client-0.7.2-0.6.1.tgz",
-      "integrity": "sha512-04rNdoeazQXB6BAeOiQmJlI/LvKC4ZyR+qt7t0LndiHELpdHTKeqbEv+MkZix8+8fzYJ39inXWhGWjodFZPq8w==",
+      "version": "0.7.20-alpha.6",
+      "resolved": "https://registry.npmjs.org/nem2-sdk-openapi-typescript-node-client/-/nem2-sdk-openapi-typescript-node-client-0.7.20-alpha.6.tgz",
+      "integrity": "sha512-6cDcxt5phUZnQi/tFzZjT1Bj+C4c0WmnIp13bd6nYV0IA8HoA7ovqEt8B7QPmj9/ukz3HwHbgaLtM299ZwhLCA==",
       "requires": {
         "@types/bluebird": "*",
         "@types/request": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,8 +58,8 @@
   },
   "dependencies": {
     "bluebird": "^3.5.5",
-    "catbuffer": "0.0.6-SNAPSHOT",
-    "nem2-sdk-openapi-typescript-node-client": "0.7.2-0.6.1",
+    "catbuffer": "0.0.7",
+    "nem2-sdk-openapi-typescript-node-client": "0.7.20-alpha.6",
     "crypto-js": "^3.1.9-1",
     "js-joda": "^1.6.2",
     "js-sha256": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.1",
+  "version": "0.16.2",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
## 06-Jan-2020

**Milestone**: Fushicho.3
 Versions  |   |
---|---|---
SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk 
Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer 
Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client 

- Refactored to replace generated codes by public library package for both `Catbuffer` and `OpenAPI Http Client`.
- Added unresolved (mosaicId, address) support in `MosaicRestrictionTransaction`.
- Added `toHex()` in `MosaicNonce` class.
- Exposed `MultisigAccountGraphInfo` class constructor to public.
- Fixed `transaction status` issue in both `Http` and `Websocket` due to schema update.
