### PR TITLE
v0.16.3 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,25 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 09-Jan-2020
+
+**Milestone**: Fushicho.3
+ Versions  |   |
+---|---|---
+SDK Core| v0.16.3 | https://www.npmjs.com/package/nem2-sdk
+Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer
+Client Library | v0.7.20-beta.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
+
+- Fixed http client (OpenAPI client package) does not support ES6 issue.
+
 ## 06-Jan-2020
 
 **Milestone**: Fushicho.3
  Versions  |   |
 ---|---|---
-SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk 
-Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer 
-Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client 
+SDK Core| v0.16.2 | https://www.npmjs.com/package/nem2-sdk
+Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer
+Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
 
 - Refactored to replace generated codes by public library package for both `Catbuffer` and `OpenAPI Http Client`.
 - Added unresolved (mosaicId, address) support in `MosaicRestrictionTransaction`.
@@ -317,7 +328,8 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 **Milestone**: Alpaca
 
 - Initial code release.
-[0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2
+[0.16.3: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3
+[0.16.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.1...v0.16.0
 [0.15.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.0...v0.15.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -328,7 +328,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 **Milestone**: Alpaca
 
 - Initial code release.
-[0.16.3: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3
+[0.16.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.0...v0.16.1
 [0.16.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.15.1...v0.16.0

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ with the NEM2 (a.k.a Catapult)
 
 ### _Fushicho_ Network Compatibility (catapult-server@0.9.1.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.2 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.3 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.16.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.0) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.16.3](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.3) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3818,9 +3818,9 @@
       }
     },
     "nem2-sdk-openapi-typescript-node-client": {
-      "version": "0.7.20-alpha.6",
-      "resolved": "https://registry.npmjs.org/nem2-sdk-openapi-typescript-node-client/-/nem2-sdk-openapi-typescript-node-client-0.7.20-alpha.6.tgz",
-      "integrity": "sha512-6cDcxt5phUZnQi/tFzZjT1Bj+C4c0WmnIp13bd6nYV0IA8HoA7ovqEt8B7QPmj9/ukz3HwHbgaLtM299ZwhLCA==",
+      "version": "0.7.20-beta.6",
+      "resolved": "https://registry.npmjs.org/nem2-sdk-openapi-typescript-node-client/-/nem2-sdk-openapi-typescript-node-client-0.7.20-beta.6.tgz",
+      "integrity": "sha512-RqoDZuPMAQ1/kStC5uAk8TFqZkLA8RuVtlpRH7TU3ZTIGylwgX95PdmKaGTUZAuoyAXo2b64OenVvt09ryZ3lw==",
       "requires": {
         "@types/bluebird": "*",
         "@types/request": "*",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "bluebird": "^3.5.5",
     "catbuffer": "0.0.7",
-    "nem2-sdk-openapi-typescript-node-client": "0.7.20-alpha.6",
+    "nem2-sdk-openapi-typescript-node-client": "0.7.20-beta.6",
     "crypto-js": "^3.1.9-1",
     "js-joda": "^1.6.2",
     "js-sha256": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
## 09-Jan-2020

**Milestone**: Fushicho.3
 Versions  |   |
---|---|---
SDK Core| v0.16.3 | https://www.npmjs.com/package/nem2-sdk
Catbuffer Library| v0.0.7 | https://www.npmjs.com/package/catbuffer
Client Library | v0.7.20-beta.6  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client

- Fixed http client (OpenAPI client package) does not support ES6 issue.
