### PR TITLE
Fixed #428 Transaction type & version enum name match

### DIFF
--- a/e2e/infrastructure/TransactionHttp.spec.ts
+++ b/e2e/infrastructure/TransactionHttp.spec.ts
@@ -531,7 +531,7 @@ describe('TransactionHttp', () => {
             const addressModification = AccountRestrictionTransaction.createOperationRestrictionModificationTransaction(
                 Deadline.create(),
                 AccountRestrictionFlags.BlockIncomingTransactionType,
-                [TransactionType.LINK_ACCOUNT],
+                [TransactionType.ACCOUNT_LINK],
                 [],
                 networkType, helper.maxFee,
             );
@@ -551,7 +551,7 @@ describe('TransactionHttp', () => {
                 Deadline.create(),
                 AccountRestrictionFlags.BlockIncomingTransactionType,
                 [],
-                [TransactionType.LINK_ACCOUNT],
+                [TransactionType.ACCOUNT_LINK],
                 networkType, helper.maxFee,
             );
             const aggregateTransaction = AggregateTransaction.createComplete(Deadline.create(),
@@ -569,12 +569,12 @@ describe('TransactionHttp', () => {
         it('standalone', () => {
             AccountRestrictionModification.createForOperation(
                 AccountRestrictionModificationAction.Add,
-                TransactionType.LINK_ACCOUNT,
+                TransactionType.ACCOUNT_LINK,
             );
             const addressModification = AccountRestrictionTransaction.createOperationRestrictionModificationTransaction(
                 Deadline.create(),
                 AccountRestrictionFlags.BlockOutgoingTransactionType,
-                [TransactionType.LINK_ACCOUNT],
+                [TransactionType.ACCOUNT_LINK],
                 [],
                 networkType, helper.maxFee,
             );
@@ -595,7 +595,7 @@ describe('TransactionHttp', () => {
                 Deadline.create(),
                 AccountRestrictionFlags.BlockOutgoingTransactionType,
                 [],
-                [TransactionType.LINK_ACCOUNT],
+                [TransactionType.ACCOUNT_LINK],
                 networkType, helper.maxFee,
             );
             const aggregateTransaction = AggregateTransaction.createComplete(Deadline.create(),

--- a/e2e/service/MetadataTransactionService.spec.ts
+++ b/e2e/service/MetadataTransactionService.spec.ts
@@ -160,7 +160,7 @@ describe('MetadataTransactionService', () => {
                 newValue,
                 targetAccount.publicAccount,
             ).subscribe((transaction: AccountMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(transaction.value).to.be.equal(newValue);
                 expect(transaction.targetPublicKey).to.be.equal(targetAccount.publicKey);
@@ -180,7 +180,7 @@ describe('MetadataTransactionService', () => {
                 targetAccount.publicAccount,
                 mosaicId,
             ).subscribe((transaction: MosaicMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(transaction.valueSizeDelta).to.be.equal(5);
                 expect(transaction.value).to.be.equal(newValue + 'delta');
@@ -202,7 +202,7 @@ describe('MetadataTransactionService', () => {
                 targetAccount.publicAccount,
                 namespaceId,
             ).subscribe((transaction: NamespaceMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(transaction.valueSizeDelta).to.be.equal(5);
                 expect(transaction.value).to.be.equal(newValue + 'delta');

--- a/src/infrastructure/transaction/CreateTransactionFromDTO.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromDTO.ts
@@ -137,7 +137,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                     transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.REGISTER_NAMESPACE) {
+    } else if (transactionDTO.type === TransactionType.NAMESPACE_REGISTRATION) {
         return new NamespaceRegistrationTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -183,7 +183,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.MODIFY_MULTISIG_ACCOUNT) {
+    } else if (transactionDTO.type === TransactionType.MULTISIG_ACCOUNT_MODIFICATION) {
         return new MultisigAccountModificationTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -200,7 +200,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.LOCK) {
+    } else if (transactionDTO.type === TransactionType.HASH_LOCK) {
         const networkType = transactionDTO.network;
         return new LockFundsTransaction(
             networkType,
@@ -276,7 +276,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.ACCOUNT_RESTRICTION_ADDRESS) {
+    } else if (transactionDTO.type === TransactionType.ACCOUNT_ADDRESS_RESTRICTION) {
         return new AccountAddressRestrictionTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -292,7 +292,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.ACCOUNT_RESTRICTION_OPERATION) {
+    } else if (transactionDTO.type === TransactionType.ACCOUNT_OPERATION_RESTRICTION) {
         return new AccountOperationRestrictionTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -306,7 +306,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.ACCOUNT_RESTRICTION_MOSAIC) {
+    } else if (transactionDTO.type === TransactionType.ACCOUNT_MOSAIC_RESTRICTION) {
         return new AccountMosaicRestrictionTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -322,7 +322,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                             transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.LINK_ACCOUNT) {
+    } else if (transactionDTO.type === TransactionType.ACCOUNT_LINK) {
         return new AccountLinkTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -369,7 +369,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                     transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.ACCOUNT_METADATA_TRANSACTION) {
+    } else if (transactionDTO.type === TransactionType.ACCOUNT_METADATA) {
         return new AccountMetadataTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -384,7 +384,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                     transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.MOSAIC_METADATA_TRANSACTION) {
+    } else if (transactionDTO.type === TransactionType.MOSAIC_METADATA) {
         return new MosaicMetadataTransaction(
             transactionDTO.network,
             transactionDTO.version,
@@ -400,7 +400,7 @@ const CreateStandaloneTransactionFromDTO = (transactionDTO, transactionInfo): Tr
                     transactionDTO.network) : undefined,
             transactionInfo,
         );
-    } else if (transactionDTO.type === TransactionType.NAMESPACE_METADATA_TRANSACTION) {
+    } else if (transactionDTO.type === TransactionType.NAMESPACE_METADATA) {
         return new NamespaceMetadataTransaction(
             transactionDTO.network,
             transactionDTO.version,

--- a/src/infrastructure/transaction/CreateTransactionFromPayload.ts
+++ b/src/infrastructure/transaction/CreateTransactionFromPayload.ts
@@ -53,19 +53,19 @@ export const CreateTransactionFromPayload = (payload: string,
         TransactionBuilder.loadFromBinary(convert.hexToUint8(payload));
     const type = transactionBuilder.getType().valueOf();
     switch (type) {
-        case TransactionType.ACCOUNT_RESTRICTION_ADDRESS:
-        case TransactionType.ACCOUNT_RESTRICTION_OPERATION:
-        case TransactionType.ACCOUNT_RESTRICTION_MOSAIC:
+        case TransactionType.ACCOUNT_ADDRESS_RESTRICTION:
+        case TransactionType.ACCOUNT_OPERATION_RESTRICTION:
+        case TransactionType.ACCOUNT_MOSAIC_RESTRICTION:
             switch (type) {
-                case TransactionType.ACCOUNT_RESTRICTION_ADDRESS:
+                case TransactionType.ACCOUNT_ADDRESS_RESTRICTION:
                     return AccountAddressRestrictionTransaction.createFromPayload(payload, isEmbedded);
-                case TransactionType.ACCOUNT_RESTRICTION_MOSAIC:
+                case TransactionType.ACCOUNT_MOSAIC_RESTRICTION:
                     return AccountMosaicRestrictionTransaction.createFromPayload(payload, isEmbedded);
-                case TransactionType.ACCOUNT_RESTRICTION_OPERATION:
+                case TransactionType.ACCOUNT_OPERATION_RESTRICTION:
                     return AccountOperationRestrictionTransaction.createFromPayload(payload, isEmbedded);
             }
             throw new Error ('Account restriction transaction type not recognised.');
-        case TransactionType.LINK_ACCOUNT:
+        case TransactionType.ACCOUNT_LINK:
             return AccountLinkTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.ADDRESS_ALIAS:
             return AddressAliasTransaction.createFromPayload(payload, isEmbedded);
@@ -75,7 +75,7 @@ export const CreateTransactionFromPayload = (payload: string,
             return MosaicDefinitionTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.MOSAIC_SUPPLY_CHANGE:
             return MosaicSupplyChangeTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.REGISTER_NAMESPACE:
+        case TransactionType.NAMESPACE_REGISTRATION:
             return NamespaceRegistrationTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.TRANSFER:
             return TransferTransaction.createFromPayload(payload, isEmbedded);
@@ -83,19 +83,19 @@ export const CreateTransactionFromPayload = (payload: string,
             return SecretLockTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.SECRET_PROOF:
             return SecretProofTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.MODIFY_MULTISIG_ACCOUNT:
+        case TransactionType.MULTISIG_ACCOUNT_MODIFICATION:
             return MultisigAccountModificationTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.LOCK:
+        case TransactionType.HASH_LOCK:
             return LockFundsTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.MOSAIC_GLOBAL_RESTRICTION:
             return MosaicGlobalRestrictionTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.MOSAIC_ADDRESS_RESTRICTION:
             return MosaicAddressRestrictionTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.ACCOUNT_METADATA_TRANSACTION:
+        case TransactionType.ACCOUNT_METADATA:
             return AccountMetadataTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.MOSAIC_METADATA_TRANSACTION:
+        case TransactionType.MOSAIC_METADATA:
             return MosaicMetadataTransaction.createFromPayload(payload, isEmbedded);
-        case TransactionType.NAMESPACE_METADATA_TRANSACTION:
+        case TransactionType.NAMESPACE_METADATA:
             return NamespaceMetadataTransaction.createFromPayload(payload, isEmbedded);
         case TransactionType.AGGREGATE_COMPLETE:
         case TransactionType.AGGREGATE_BONDED:

--- a/src/infrastructure/transaction/SerializeTransactionToJSON.ts
+++ b/src/infrastructure/transaction/SerializeTransactionToJSON.ts
@@ -46,7 +46,7 @@ import { TransferTransaction } from '../../model/transaction/TransferTransaction
  */
 export const SerializeTransactionToJSON = (transaction: Transaction): any => {
     switch (transaction.type) {
-        case TransactionType.LINK_ACCOUNT:
+        case TransactionType.ACCOUNT_LINK:
             const accountLinkTx = transaction as AccountLinkTransaction;
             return {
                 remotePublicKey: accountLinkTx.remotePublicKey,
@@ -70,7 +70,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                     return cosignature.toDTO();
                 }),
             };
-        case TransactionType.LOCK:
+        case TransactionType.HASH_LOCK:
             const LockFundTx = transaction as LockFundsTransaction;
             return {
                 mosaicId: LockFundTx.mosaic.id.id,
@@ -78,7 +78,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                 duration: LockFundTx.duration.toString(),
                 hash: LockFundTx.hash,
             };
-        case TransactionType.ACCOUNT_RESTRICTION_ADDRESS:
+        case TransactionType.ACCOUNT_ADDRESS_RESTRICTION:
             const accountAddressRestrictionTx = transaction as AccountAddressRestrictionTransaction;
             return {
                 restrictionFlags: accountAddressRestrictionTx.restrictionFlags,
@@ -91,7 +91,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                     return deletion.toDTO();
                 }),
             };
-        case TransactionType.ACCOUNT_RESTRICTION_OPERATION:
+        case TransactionType.ACCOUNT_OPERATION_RESTRICTION:
             const accountOperationRestrictionTx = transaction as AccountOperationRestrictionTransaction;
             return {
                 restrictionFlags: accountOperationRestrictionTx.restrictionFlags,
@@ -104,7 +104,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                     return deletion;
                 }),
             };
-        case TransactionType.ACCOUNT_RESTRICTION_MOSAIC:
+        case TransactionType.ACCOUNT_MOSAIC_RESTRICTION:
             const accountMosaicRestrictionTx = transaction as AccountMosaicRestrictionTransaction;
             return {
                 restrictionFlags: accountMosaicRestrictionTx.restrictionFlags,
@@ -117,7 +117,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                     return deletion.toHex();
                 }),
             };
-        case TransactionType.MODIFY_MULTISIG_ACCOUNT:
+        case TransactionType.MULTISIG_ACCOUNT_MODIFICATION:
             const multisigTx = transaction as MultisigAccountModificationTransaction;
             return {
                 minApprovalDelta: multisigTx.minApprovalDelta,
@@ -152,7 +152,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                 action: mosaicSupplyTx.action,
                 delta: mosaicSupplyTx.delta.toString(),
             };
-        case TransactionType.REGISTER_NAMESPACE:
+        case TransactionType.NAMESPACE_REGISTRATION:
             const namespaceTx = transaction as NamespaceRegistrationTransaction;
             const registerNamespaceDuration = namespaceTx.duration;
             const registerNamespaceParentId = namespaceTx.parentId;
@@ -218,7 +218,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                 newRestrictionValue: mosaicAddressRestrictionTx.newRestrictionValue.toString(),
 
             };
-        case TransactionType.ACCOUNT_METADATA_TRANSACTION:
+        case TransactionType.ACCOUNT_METADATA:
             const accountMetadataTx = transaction as AccountMetadataTransaction;
             return {
                 targetPublicKey: accountMetadataTx.targetPublicKey,
@@ -228,7 +228,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                 value: Convert.utf8ToHex(accountMetadataTx.value),
 
             };
-        case TransactionType.MOSAIC_METADATA_TRANSACTION:
+        case TransactionType.MOSAIC_METADATA:
             const mosaicMetadataTx = transaction as MosaicMetadataTransaction;
             return {
                 targetPublicKey: mosaicMetadataTx.targetPublicKey,
@@ -239,7 +239,7 @@ export const SerializeTransactionToJSON = (transaction: Transaction): any => {
                 value: Convert.utf8ToHex(mosaicMetadataTx.value),
 
             };
-        case TransactionType.NAMESPACE_METADATA_TRANSACTION:
+        case TransactionType.NAMESPACE_METADATA:
             const namespaceMetaTx = transaction as NamespaceMetadataTransaction;
             return {
                 targetPublicKey: namespaceMetaTx.targetPublicKey,

--- a/src/model/transaction/AccountAddressRestrictionTransaction.ts
+++ b/src/model/transaction/AccountAddressRestrictionTransaction.ts
@@ -60,7 +60,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): AccountAddressRestrictionTransaction {
         return new AccountAddressRestrictionTransaction(networkType,
-            TransactionVersion.ACCOUNT_RESTRICTION_ADDRESS,
+            TransactionVersion.ACCOUNT_ADDRESS_RESTRICTION,
             deadline,
             maxFee,
             restrictionFlags,
@@ -90,7 +90,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.ACCOUNT_RESTRICTION_ADDRESS,
+        super(TransactionType.ACCOUNT_ADDRESS_RESTRICTION,
               networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
@@ -158,7 +158,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_ADDRESS.valueOf(),
+            TransactionType.ACCOUNT_ADDRESS_RESTRICTION.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             this.restrictionFlags.valueOf(),
@@ -181,7 +181,7 @@ export class AccountAddressRestrictionTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_ADDRESS.valueOf(),
+            TransactionType.ACCOUNT_ADDRESS_RESTRICTION.valueOf(),
             this.restrictionFlags.valueOf(),
             this.restrictionAdditions.map((addition) => {
                 return new UnresolvedAddressDto(UnresolvedMapping.toUnresolvedAddressBytes(addition, this.networkType));

--- a/src/model/transaction/AccountLinkTransaction.ts
+++ b/src/model/transaction/AccountLinkTransaction.ts
@@ -54,7 +54,7 @@ export class AccountLinkTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): AccountLinkTransaction {
         return new AccountLinkTransaction(networkType,
-            TransactionVersion.LINK_ACCOUNT,
+            TransactionVersion.ACCOUNT_LINK,
             deadline,
             maxFee,
             remotePublicKey,
@@ -87,7 +87,7 @@ export class AccountLinkTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.LINK_ACCOUNT, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.ACCOUNT_LINK, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
     /**
@@ -142,7 +142,7 @@ export class AccountLinkTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.LINK_ACCOUNT.valueOf(),
+            TransactionType.ACCOUNT_LINK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new KeyDto(Convert.hexToUint8(this.remotePublicKey)),
@@ -160,7 +160,7 @@ export class AccountLinkTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.LINK_ACCOUNT.valueOf(),
+            TransactionType.ACCOUNT_LINK.valueOf(),
             new KeyDto(Convert.hexToUint8(this.remotePublicKey)),
             this.linkAction.valueOf(),
         );

--- a/src/model/transaction/AccountMetadataTransaction.ts
+++ b/src/model/transaction/AccountMetadataTransaction.ts
@@ -59,7 +59,7 @@ export class AccountMetadataTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): AccountMetadataTransaction {
         return new AccountMetadataTransaction(networkType,
-            TransactionVersion.ACCOUNT_METADATA_TRANSACTION,
+            TransactionVersion.ACCOUNT_METADATA,
             deadline,
             maxFee,
             targetPublicKey,
@@ -105,7 +105,7 @@ export class AccountMetadataTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.ACCOUNT_METADATA_TRANSACTION, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.ACCOUNT_METADATA, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
         if (value.length > 1024) {
             throw new Error('The maximum value size is 1024');
         }
@@ -168,7 +168,7 @@ export class AccountMetadataTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_METADATA_TRANSACTION.valueOf(),
+            TransactionType.ACCOUNT_METADATA.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
@@ -188,7 +188,7 @@ export class AccountMetadataTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_METADATA_TRANSACTION.valueOf(),
+            TransactionType.ACCOUNT_METADATA.valueOf(),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
             this.scopedMetadataKey.toDTO(),
             this.valueSizeDelta,

--- a/src/model/transaction/AccountMosaicRestrictionTransaction.ts
+++ b/src/model/transaction/AccountMosaicRestrictionTransaction.ts
@@ -60,7 +60,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): AccountMosaicRestrictionTransaction {
         return new AccountMosaicRestrictionTransaction(networkType,
-            TransactionVersion.ACCOUNT_RESTRICTION_MOSAIC,
+            TransactionVersion.ACCOUNT_MOSAIC_RESTRICTION,
             deadline,
             maxFee,
             restrictionFlags,
@@ -90,7 +90,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.ACCOUNT_RESTRICTION_MOSAIC,
+        super(TransactionType.ACCOUNT_MOSAIC_RESTRICTION,
               networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
@@ -158,7 +158,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_MOSAIC.valueOf(),
+            TransactionType.ACCOUNT_MOSAIC_RESTRICTION.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             this.restrictionFlags.valueOf(),
@@ -181,7 +181,7 @@ export class AccountMosaicRestrictionTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_MOSAIC.valueOf(),
+            TransactionType.ACCOUNT_MOSAIC_RESTRICTION.valueOf(),
             this.restrictionFlags.valueOf(),
             this.restrictionAdditions.map((addition) => {
                 return new UnresolvedMosaicIdDto(addition.id.toDTO());

--- a/src/model/transaction/AccountOperationRestrictionTransaction.ts
+++ b/src/model/transaction/AccountOperationRestrictionTransaction.ts
@@ -84,7 +84,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.ACCOUNT_RESTRICTION_OPERATION,
+        super(TransactionType.ACCOUNT_OPERATION_RESTRICTION,
               networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
@@ -147,7 +147,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_OPERATION.valueOf(),
+            TransactionType.ACCOUNT_OPERATION_RESTRICTION.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             this.restrictionFlags.valueOf(),
@@ -166,7 +166,7 @@ export class AccountOperationRestrictionTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.ACCOUNT_RESTRICTION_OPERATION.valueOf(),
+            TransactionType.ACCOUNT_OPERATION_RESTRICTION.valueOf(),
             this.restrictionFlags.valueOf(),
             this.restrictionAdditions,
             this.restrictionDeletions,

--- a/src/model/transaction/LockFundsTransaction.ts
+++ b/src/model/transaction/LockFundsTransaction.ts
@@ -75,7 +75,7 @@ export class LockFundsTransaction extends Transaction {
                          maxFee: UInt64 = new UInt64([0, 0])): LockFundsTransaction {
         return new LockFundsTransaction(
             networkType,
-            TransactionVersion.LOCK,
+            TransactionVersion.HASH_LOCK,
             deadline,
             maxFee,
             mosaic,
@@ -112,7 +112,7 @@ export class LockFundsTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.LOCK, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.HASH_LOCK, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
         this.hash = signedTransaction.hash;
         this.signedTransaction = signedTransaction;
         if (signedTransaction.type !== TransactionType.AGGREGATE_BONDED) {
@@ -178,7 +178,7 @@ export class LockFundsTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.LOCK.valueOf(),
+            TransactionType.HASH_LOCK.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new UnresolvedMosaicBuilder(new UnresolvedMosaicIdDto(this.mosaic.id.id.toDTO()),
@@ -198,7 +198,7 @@ export class LockFundsTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.LOCK.valueOf(),
+            TransactionType.HASH_LOCK.valueOf(),
             new UnresolvedMosaicBuilder(new UnresolvedMosaicIdDto(this.mosaic.id.id.toDTO()),
                                                    new AmountDto(this.mosaic.amount.toDTO())),
             new BlockDurationDto(this.duration.toDTO()),

--- a/src/model/transaction/MosaicMetadataTransaction.ts
+++ b/src/model/transaction/MosaicMetadataTransaction.ts
@@ -67,7 +67,7 @@ export class MosaicMetadataTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): MosaicMetadataTransaction {
         return new MosaicMetadataTransaction(networkType,
-            TransactionVersion.MOSAIC_METADATA_TRANSACTION,
+            TransactionVersion.MOSAIC_METADATA,
             deadline,
             maxFee,
             targetPublicKey,
@@ -119,7 +119,7 @@ export class MosaicMetadataTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.MOSAIC_METADATA_TRANSACTION, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.MOSAIC_METADATA, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
         if (value.length > 1024) {
             throw new Error('The maximum value size is 1024');
         }
@@ -184,7 +184,7 @@ export class MosaicMetadataTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.MOSAIC_METADATA_TRANSACTION.valueOf(),
+            TransactionType.MOSAIC_METADATA.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
@@ -205,7 +205,7 @@ export class MosaicMetadataTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.MOSAIC_METADATA_TRANSACTION.valueOf(),
+            TransactionType.MOSAIC_METADATA.valueOf(),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
             this.scopedMetadataKey.toDTO(),
             new UnresolvedMosaicIdDto(this.targetMosaicId.id.toDTO()),

--- a/src/model/transaction/MultisigAccountModificationTransaction.ts
+++ b/src/model/transaction/MultisigAccountModificationTransaction.ts
@@ -61,7 +61,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): MultisigAccountModificationTransaction {
         return new MultisigAccountModificationTransaction(networkType,
-            TransactionVersion.MODIFY_MULTISIG_ACCOUNT,
+            TransactionVersion.MULTISIG_ACCOUNT_MODIFICATION,
             deadline,
             maxFee,
             minApprovalDelta,
@@ -108,7 +108,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.MODIFY_MULTISIG_ACCOUNT, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.MULTISIG_ACCOUNT_MODIFICATION, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
     /**
@@ -176,7 +176,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.MODIFY_MULTISIG_ACCOUNT.valueOf(),
+            TransactionType.MULTISIG_ACCOUNT_MODIFICATION.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             this.minRemovalDelta,
@@ -200,7 +200,7 @@ export class MultisigAccountModificationTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.MODIFY_MULTISIG_ACCOUNT.valueOf(),
+            TransactionType.MULTISIG_ACCOUNT_MODIFICATION.valueOf(),
             this.minRemovalDelta,
             this.minApprovalDelta,
             this.publicKeyAdditions.map((addition) => {

--- a/src/model/transaction/NamespaceMetadataTransaction.ts
+++ b/src/model/transaction/NamespaceMetadataTransaction.ts
@@ -63,7 +63,7 @@ export class NamespaceMetadataTransaction extends Transaction {
                          networkType: NetworkType,
                          maxFee: UInt64 = new UInt64([0, 0])): NamespaceMetadataTransaction {
         return new NamespaceMetadataTransaction(networkType,
-            TransactionVersion.NAMESPACE_METADATA_TRANSACTION,
+            TransactionVersion.NAMESPACE_METADATA,
             deadline,
             maxFee,
             targetPublicKey,
@@ -115,7 +115,7 @@ export class NamespaceMetadataTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.NAMESPACE_METADATA_TRANSACTION, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.NAMESPACE_METADATA, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
         if (value.length > 1024) {
             throw new Error('The maximum value size is 1024');
         }
@@ -181,7 +181,7 @@ export class NamespaceMetadataTransaction extends Transaction {
             new KeyDto(signerBuffer),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.NAMESPACE_METADATA_TRANSACTION.valueOf(),
+            TransactionType.NAMESPACE_METADATA.valueOf(),
             new AmountDto(this.maxFee.toDTO()),
             new TimestampDto(this.deadline.toDTO()),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
@@ -202,7 +202,7 @@ export class NamespaceMetadataTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.NAMESPACE_METADATA_TRANSACTION.valueOf(),
+            TransactionType.NAMESPACE_METADATA.valueOf(),
             new KeyDto(Convert.hexToUint8(this.targetPublicKey)),
             this.scopedMetadataKey.toDTO(),
             new NamespaceIdDto(this.targetNamespaceId.id.toDTO()),

--- a/src/model/transaction/NamespaceRegistrationTransaction.ts
+++ b/src/model/transaction/NamespaceRegistrationTransaction.ts
@@ -60,7 +60,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                                       networkType: NetworkType,
                                       maxFee: UInt64 = new UInt64([0, 0])): NamespaceRegistrationTransaction {
         return new NamespaceRegistrationTransaction(networkType,
-            TransactionVersion.REGISTER_NAMESPACE,
+            TransactionVersion.NAMESPACE_REGISTRATION,
             deadline,
             maxFee,
             NamespaceRegistrationType.RootNamespace,
@@ -91,7 +91,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
             parentId = parentNamespace;
         }
         return new NamespaceRegistrationTransaction(networkType,
-            TransactionVersion.REGISTER_NAMESPACE,
+            TransactionVersion.NAMESPACE_REGISTRATION,
             deadline,
             maxFee,
             NamespaceRegistrationType.SubNamespace,
@@ -146,7 +146,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 signature?: string,
                 signer?: PublicAccount,
                 transactionInfo?: TransactionInfo) {
-        super(TransactionType.REGISTER_NAMESPACE, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
+        super(TransactionType.NAMESPACE_REGISTRATION, networkType, version, deadline, maxFee, signature, signer, transactionInfo);
     }
 
     /**
@@ -217,7 +217,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 new KeyDto(signerBuffer),
                 this.versionToDTO(),
                 this.networkType.valueOf(),
-                TransactionType.REGISTER_NAMESPACE.valueOf(),
+                TransactionType.NAMESPACE_REGISTRATION.valueOf(),
                 new AmountDto(this.maxFee.toDTO()),
                 new TimestampDto(this.deadline.toDTO()),
                 new NamespaceIdDto(this.namespaceId.id.toDTO()),
@@ -231,7 +231,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 new KeyDto(signerBuffer),
                 this.versionToDTO(),
                 this.networkType.valueOf(),
-                TransactionType.REGISTER_NAMESPACE.valueOf(),
+                TransactionType.NAMESPACE_REGISTRATION.valueOf(),
                 new AmountDto(this.maxFee.toDTO()),
                 new TimestampDto(this.deadline.toDTO()),
                 new NamespaceIdDto(this.namespaceId.id.toDTO()),
@@ -253,7 +253,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
                 new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
                 this.versionToDTO(),
                 this.networkType.valueOf(),
-                TransactionType.REGISTER_NAMESPACE.valueOf(),
+                TransactionType.NAMESPACE_REGISTRATION.valueOf(),
                 new NamespaceIdDto(this.namespaceId.id.toDTO()),
                 Convert.hexToUint8(Convert.utf8ToHex(this.namespaceName)),
                 new BlockDurationDto(this.duration!.toDTO()),
@@ -264,7 +264,7 @@ export class NamespaceRegistrationTransaction extends Transaction {
             new KeyDto(Convert.hexToUint8(this.signer!.publicKey)),
             this.versionToDTO(),
             this.networkType.valueOf(),
-            TransactionType.REGISTER_NAMESPACE.valueOf(),
+            TransactionType.NAMESPACE_REGISTRATION.valueOf(),
             new NamespaceIdDto(this.namespaceId.id.toDTO()),
             Convert.hexToUint8(Convert.utf8ToHex(this.namespaceName)),
             undefined,

--- a/src/model/transaction/TransactionType.ts
+++ b/src/model/transaction/TransactionType.ts
@@ -31,7 +31,7 @@ export enum TransactionType {
      * Register namespace transaction type.
      * @type {number}
      */
-    REGISTER_NAMESPACE = 0x414E,
+    NAMESPACE_REGISTRATION = 0x414E,
 
     /**
      * Address alias transaction type
@@ -61,7 +61,7 @@ export enum TransactionType {
      * Modify multisig account transaction type.
      * @type {number}
      */
-    MODIFY_MULTISIG_ACCOUNT = 0x4155,
+    MULTISIG_ACCOUNT_MODIFICATION = 0x4155,
 
     /**
      * Aggregate complete transaction type.
@@ -78,7 +78,7 @@ export enum TransactionType {
      * Lock transaction type
      * @type {number}
      */
-    LOCK = 0x4148,
+    HASH_LOCK = 0x4148,
 
     /**
      * Secret Lock Transaction type
@@ -96,25 +96,25 @@ export enum TransactionType {
      * Account restriction address transaction type
      * @type {number}
      */
-    ACCOUNT_RESTRICTION_ADDRESS = 0x4150,
+    ACCOUNT_ADDRESS_RESTRICTION = 0x4150,
 
     /**
      * Account restriction mosaic transaction type
      * @type {number}
      */
-    ACCOUNT_RESTRICTION_MOSAIC = 0x4250,
+    ACCOUNT_MOSAIC_RESTRICTION = 0x4250,
 
     /**
      * Account restriction operation transaction type
      * @type {number}
      */
-   ACCOUNT_RESTRICTION_OPERATION = 0x4350,
+    ACCOUNT_OPERATION_RESTRICTION = 0x4350,
 
     /**
      * Link account transaction type
      * @type {number}
      */
-    LINK_ACCOUNT = 0x414C,
+    ACCOUNT_LINK = 0x414C,
 
     /**
      * Mosaic address restriction type
@@ -132,17 +132,17 @@ export enum TransactionType {
      * Account metadata transaction
      * @type {number}
      */
-    ACCOUNT_METADATA_TRANSACTION = 0x4144,
+    ACCOUNT_METADATA = 0x4144,
 
     /**
      * Mosaic metadata transaction
      * @type {number}
      */
-    MOSAIC_METADATA_TRANSACTION = 0x4244,
+    MOSAIC_METADATA = 0x4244,
 
     /**
      * Namespace metadata transaction
      * @type {number}
      */
-    NAMESPACE_METADATA_TRANSACTION = 0x4344,
+    NAMESPACE_METADATA = 0x4344,
 }

--- a/src/model/transaction/TransactionVersion.ts
+++ b/src/model/transaction/TransactionVersion.ts
@@ -37,7 +37,7 @@ export class TransactionVersion {
      * Register namespace transaction version.
      * @type {number}
      */
-    public static readonly REGISTER_NAMESPACE = 0x01;
+    public static readonly NAMESPACE_REGISTRATION = 0x01;
 
     /**
      * Mosaic definition transaction version.
@@ -55,7 +55,7 @@ export class TransactionVersion {
      * Modify multisig account transaction version.
      * @type {number}
      */
-    public static readonly MODIFY_MULTISIG_ACCOUNT = 0x01;
+    public static readonly MULTISIG_ACCOUNT_MODIFICATION = 0x01;
 
     /**
      * Aggregate complete transaction version.
@@ -72,7 +72,7 @@ export class TransactionVersion {
      * Lock transaction version
      * @type {number}
      */
-    public static readonly LOCK = 0x01;
+    public static readonly HASH_LOCK = 0x01;
 
     /**
      * Secret Lock transaction version
@@ -114,13 +114,13 @@ export class TransactionVersion {
      * Account Restriction address transaction version
      * @type {number}
      */
-    public static readonly ACCOUNT_RESTRICTION_ADDRESS = 0x01;
+    public static readonly ACCOUNT_ADDRESS_RESTRICTION = 0x01;
 
     /**
      * Account Restriction mosaic transaction version
      * @type {number}
      */
-    public static readonly ACCOUNT_RESTRICTION_MOSAIC = 0x01;
+    public static readonly ACCOUNT_MOSAIC_RESTRICTION = 0x01;
 
     /**
      * Account Restriction operation transaction version
@@ -132,23 +132,23 @@ export class TransactionVersion {
      * Link account transaction version
      * @type {number}
      */
-    public static readonly LINK_ACCOUNT = 0x01;
+    public static readonly ACCOUNT_LINK = 0x01;
 
     /**
      * Account metadata transaction version
      * @type {number}
      */
-    public static readonly ACCOUNT_METADATA_TRANSACTION = 0x01;
+    public static readonly ACCOUNT_METADATA = 0x01;
 
     /**
      * Mosaic metadata transaction version
      * @type {number}
      */
-    public static readonly MOSAIC_METADATA_TRANSACTION = 0x01;
+    public static readonly MOSAIC_METADATA = 0x01;
 
     /**
      * Namespace metadata transaction version
      * @type {number}
      */
-    public static readonly NAMESPACE_METADATA_TRANSACTION = 0x01;
+    public static readonly NAMESPACE_METADATA = 0x01;
 }

--- a/src/service/AggregateTransactionService.ts
+++ b/src/service/AggregateTransactionService.ts
@@ -96,7 +96,7 @@ export class AggregateTransactionService {
          * Check inner transaction. If remove cosigner from multisig account,
          * use minRemoval instead of minApproval for cosignatories validation.
          */
-        if (innerTransaction.type === TransactionType.MODIFY_MULTISIG_ACCOUNT) {
+        if (innerTransaction.type === TransactionType.MULTISIG_ACCOUNT_MODIFICATION) {
             if ((innerTransaction as MultisigAccountModificationTransaction).publicKeyDeletions.length) {
                         isMultisigRemoval = true;
             }

--- a/src/service/TransactionService.ts
+++ b/src/service/TransactionService.ts
@@ -126,25 +126,25 @@ export class TransactionService implements ITransactionService {
      */
     private checkShouldResolve(transaction: Transaction): boolean {
         switch (transaction.type) {
-            case TransactionType.LINK_ACCOUNT:
-            case TransactionType.ACCOUNT_METADATA_TRANSACTION:
-            case TransactionType.ACCOUNT_RESTRICTION_OPERATION:
+            case TransactionType.ACCOUNT_LINK:
+            case TransactionType.ACCOUNT_METADATA:
+            case TransactionType.ACCOUNT_OPERATION_RESTRICTION:
             case TransactionType.ADDRESS_ALIAS:
             case TransactionType.MOSAIC_ALIAS:
             case TransactionType.MOSAIC_DEFINITION:
-            case TransactionType.MODIFY_MULTISIG_ACCOUNT:
-            case TransactionType.NAMESPACE_METADATA_TRANSACTION:
-            case TransactionType.REGISTER_NAMESPACE:
+            case TransactionType.MULTISIG_ACCOUNT_MODIFICATION:
+            case TransactionType.NAMESPACE_METADATA:
+            case TransactionType.NAMESPACE_REGISTRATION:
                 return false;
-            case TransactionType.ACCOUNT_RESTRICTION_ADDRESS:
+            case TransactionType.ACCOUNT_ADDRESS_RESTRICTION:
                 const accountAddressRestriction = transaction as AccountAddressRestrictionTransaction;
                 return accountAddressRestriction.restrictionAdditions.find((address) => address instanceof NamespaceId) !== undefined ||
                     accountAddressRestriction.restrictionDeletions.find((address) => address instanceof NamespaceId) !== undefined;
-            case TransactionType.ACCOUNT_RESTRICTION_MOSAIC:
+            case TransactionType.ACCOUNT_MOSAIC_RESTRICTION:
                 const accountMosaicRestriction = transaction as AccountAddressRestrictionTransaction;
                 return accountMosaicRestriction.restrictionAdditions.find((mosaicId) => mosaicId instanceof NamespaceId) !== undefined ||
                     accountMosaicRestriction.restrictionDeletions.find((mosaicId) => mosaicId instanceof NamespaceId) !== undefined;
-            case TransactionType.LOCK:
+            case TransactionType.HASH_LOCK:
                 return (transaction as LockFundsTransaction).mosaic.id instanceof NamespaceId;
             case TransactionType.MOSAIC_ADDRESS_RESTRICTION:
                 const mosaicAddressRestriction = transaction as MosaicAddressRestrictionTransaction;
@@ -154,7 +154,7 @@ export class TransactionService implements ITransactionService {
                 const mosaicGlobalRestriction = transaction as MosaicGlobalRestrictionTransaction;
                 return mosaicGlobalRestriction.referenceMosaicId instanceof NamespaceId ||
                     mosaicGlobalRestriction.mosaicId instanceof NamespaceId;
-            case TransactionType.MOSAIC_METADATA_TRANSACTION:
+            case TransactionType.MOSAIC_METADATA:
                 return (transaction as MosaicMetadataTransaction).targetMosaicId instanceof NamespaceId;
             case TransactionType.MOSAIC_SUPPLY_CHANGE:
                 return (transaction as MosaicSupplyChangeTransaction).mosaicId instanceof NamespaceId;

--- a/test/core/utils/TransactionMapping.spec.ts
+++ b/test/core/utils/TransactionMapping.spec.ts
@@ -610,7 +610,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
         const transaction = TransactionMapping.createFromPayload(signedTx.payload) as AccountMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
@@ -632,7 +632,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
         const transaction = TransactionMapping.createFromPayload(signedTx.payload) as MosaicMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
@@ -655,7 +655,7 @@ describe('TransactionMapping - createFromPayload', () => {
 
         const transaction = TransactionMapping.createFromPayload(signedTx.payload) as NamespaceMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
@@ -767,7 +767,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(mosaicRestrictionTransaction.toJSON()) as AccountMosaicRestrictionTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_RESTRICTION_MOSAIC);
+        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_MOSAIC_RESTRICTION);
         expect(transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowMosaic);
         expect(transaction.restrictionAdditions.length).to.be.equal(1);
     });
@@ -785,7 +785,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(operationRestrictionTransaction.toJSON()) as AccountMosaicRestrictionTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_RESTRICTION_OPERATION);
+        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_OPERATION_RESTRICTION);
         expect(transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowIncomingTransactionType);
         expect(transaction.restrictionAdditions.length).to.be.equal(1);
     });
@@ -991,7 +991,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(modifyMultisigAccountTransaction.toJSON()) as MultisigAccountModificationTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.MODIFY_MULTISIG_ACCOUNT);
+        expect(transaction.type).to.be.equal(TransactionType.MULTISIG_ACCOUNT_MODIFICATION);
         expect(transaction.minApprovalDelta).to.be.equal(2);
         expect(transaction.minRemovalDelta).to.be.equal(1);
     });
@@ -1057,7 +1057,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(lockTransaction.toJSON()) as LockFundsTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.LOCK);
+        expect(transaction.type).to.be.equal(TransactionType.HASH_LOCK);
         expect(transaction.hash).to.be.equal(signedTransaction.hash);
     });
 
@@ -1072,7 +1072,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(registerNamespaceTransaction.toJSON()) as NamespaceRegistrationTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.REGISTER_NAMESPACE);
+        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_REGISTRATION);
 
     });
 
@@ -1086,7 +1086,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(registerNamespaceTransaction.toJSON()) as NamespaceRegistrationTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.REGISTER_NAMESPACE);
+        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_REGISTRATION);
     });
 
     it('should create MosaicGlobalRestrictionTransaction', () => {
@@ -1149,7 +1149,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(accountMetadataTransaction.toJSON()) as AccountMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
@@ -1170,7 +1170,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(mosaicMetadataTransaction.toJSON()) as MosaicMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toHex()).to.be.equal(UInt64.fromUint(1000).toHex());
         expect(transaction.valueSizeDelta).to.be.equal(1);
@@ -1192,7 +1192,7 @@ describe('TransactionMapping - createFromDTO (Transaction.toJSON() feed)', () =>
         const transaction =
             TransactionMapping.createFromDTO(namespaceMetadataTransaction.toJSON()) as NamespaceMetadataTransaction;
 
-        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA_TRANSACTION);
+        expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
         expect(transaction.targetPublicKey).to.be.equal(account.publicKey);
         expect(transaction.scopedMetadataKey.toString()).to.be.equal(UInt64.fromUint(1000).toString());
         expect(transaction.valueSizeDelta).to.be.equal(1);

--- a/test/infrastructure/SerializeTransactionToJSON.spec.ts
+++ b/test/infrastructure/SerializeTransactionToJSON.spec.ts
@@ -83,7 +83,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = addressRestrictionTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_RESTRICTION_ADDRESS);
+        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_ADDRESS_RESTRICTION);
         expect(json.transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowIncomingAddress);
         expect(json.transaction.restrictionAdditions.length).to.be.equal(1);
     });
@@ -100,7 +100,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = mosaicRestrictionTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_RESTRICTION_MOSAIC);
+        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_MOSAIC_RESTRICTION);
         expect(json.transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowMosaic);
         expect(json.transaction.restrictionAdditions.length).to.be.equal(1);
     });
@@ -117,7 +117,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = operationRestrictionTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_RESTRICTION_OPERATION);
+        expect(json.transaction.type).to.be.equal(TransactionType.ACCOUNT_OPERATION_RESTRICTION);
         expect(json.transaction.restrictionFlags).to.be.equal(AccountRestrictionFlags.AllowIncomingTransactionType);
         expect(json.transaction.restrictionAdditions.length).to.be.equal(1);
     });
@@ -284,7 +284,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = modifyMultisigAccountTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.MODIFY_MULTISIG_ACCOUNT);
+        expect(json.transaction.type).to.be.equal(TransactionType.MULTISIG_ACCOUNT_MODIFICATION);
         expect(json.transaction.minApprovalDelta).to.be.equal(2);
         expect(json.transaction.minRemovalDelta).to.be.equal(1);
     });
@@ -348,7 +348,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = lockTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.LOCK);
+        expect(json.transaction.type).to.be.equal(TransactionType.HASH_LOCK);
         expect(json.transaction.hash).to.be.equal(signedTransaction.hash);
     });
 
@@ -362,7 +362,7 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = registerNamespaceTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.REGISTER_NAMESPACE);
+        expect(json.transaction.type).to.be.equal(TransactionType.NAMESPACE_REGISTRATION);
 
     });
 
@@ -376,6 +376,6 @@ describe('SerializeTransactionToJSON', () => {
 
         const json = registerNamespaceTransaction.toJSON();
 
-        expect(json.transaction.type).to.be.equal(TransactionType.REGISTER_NAMESPACE);
+        expect(json.transaction.type).to.be.equal(TransactionType.NAMESPACE_REGISTRATION);
     });
 });

--- a/test/infrastructure/transaction/ValidateTransaction.ts
+++ b/test/infrastructure/transaction/ValidateTransaction.ts
@@ -52,13 +52,13 @@ const ValidateTransaction = {
 
         if (transaction.type === TransactionType.TRANSFER) {
             ValidateTransaction.validateTransferTx(transaction, transactionDTO);
-        } else if (transaction.type === TransactionType.REGISTER_NAMESPACE) {
+        } else if (transaction.type === TransactionType.NAMESPACE_REGISTRATION) {
             ValidateTransaction.validateNamespaceCreationTx(transaction, transactionDTO);
         } else if (transaction.type === TransactionType.MOSAIC_DEFINITION) {
             ValidateTransaction.validateMosaicCreationTx(transaction, transactionDTO);
         } else if (transaction.type === TransactionType.MOSAIC_SUPPLY_CHANGE) {
             ValidateTransaction.validateMosaicSupplyChangeTx(transaction, transactionDTO);
-        } else if (transaction.type === TransactionType.MODIFY_MULTISIG_ACCOUNT) {
+        } else if (transaction.type === TransactionType.MULTISIG_ACCOUNT_MODIFICATION) {
             ValidateTransaction.validateMultisigModificationTx(transaction, transactionDTO);
         }
     },

--- a/test/model/transaction/TransactionType.spec.ts
+++ b/test/model/transaction/TransactionType.spec.ts
@@ -19,14 +19,14 @@ import {TransactionType} from '../../../src/model/transaction/TransactionType';
 describe('TransactionType', () => {
     it('Should match the specification', () => {
         expect(TransactionType.TRANSFER).to.be.equal(0x4154);
-        expect(TransactionType.REGISTER_NAMESPACE).to.be.equal(0x414E);
+        expect(TransactionType.NAMESPACE_REGISTRATION).to.be.equal(0x414E);
         expect(TransactionType.MOSAIC_DEFINITION).to.be.equal(0x414D);
         expect(TransactionType.MOSAIC_SUPPLY_CHANGE).to.be.equal(0x424D);
-        expect(TransactionType.MODIFY_MULTISIG_ACCOUNT).to.be.equal(0x4155);
+        expect(TransactionType.MULTISIG_ACCOUNT_MODIFICATION).to.be.equal(0x4155);
         expect(TransactionType.AGGREGATE_COMPLETE).to.be.equal(0x4141);
         expect(TransactionType.AGGREGATE_BONDED).to.be.equal(0x4241);
         expect(TransactionType.AGGREGATE_BONDED).to.be.equal(0x4241);
-        expect(TransactionType.LOCK).to.be.equal(0x4148);
+        expect(TransactionType.HASH_LOCK).to.be.equal(0x4148);
         expect(TransactionType.SECRET_LOCK).to.be.equal(0x4152);
         expect(TransactionType.SECRET_PROOF).to.be.equal(0x4252);
     });

--- a/test/service/MetadataTransactionservice.spec.ts
+++ b/test/service/MetadataTransactionservice.spec.ts
@@ -69,7 +69,7 @@ describe('MetadataTransactionService', () => {
                                                              value + deltaValue,
                                                              account.publicAccount)
             .subscribe((transaction: AccountMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.ACCOUNT_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(Convert.utf8ToHex(transaction.value))
                     .to.be.equal(Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)));
@@ -89,7 +89,7 @@ describe('MetadataTransactionService', () => {
                                                              account.publicAccount,
                                                              new MosaicId(targetIdHex))
             .subscribe((transaction: MosaicMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.MOSAIC_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(Convert.utf8ToHex(transaction.value))
                     .to.be.equal(Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)));
@@ -110,7 +110,7 @@ describe('MetadataTransactionService', () => {
                                                              account.publicAccount,
                                                              NamespaceId.createFromEncoded(targetIdHex))
             .subscribe((transaction: NamespaceMetadataTransaction) => {
-                expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA_TRANSACTION);
+                expect(transaction.type).to.be.equal(TransactionType.NAMESPACE_METADATA);
                 expect(transaction.scopedMetadataKey.toHex()).to.be.equal(key.toHex());
                 expect(Convert.utf8ToHex(transaction.value))
                     .to.be.equal(Convert.xor(Convert.utf8ToUint8(value), Convert.utf8ToUint8(value + deltaValue)));


### PR DESCRIPTION
Renamed TransactionType and TransactionVersion enum names to match Catapult doc

Fixed #428 