### PR TITLE
v0.16.4 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.16.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2
 [0.16.1]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.0...v0.16.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 30-Jan-2020
+
+**Milestone**: Fushicho.4(RC3)
+ Versions  |   |
+---|---|---
+SDK Core| v0.16.4 | https://www.npmjs.com/package/nem2-sdk
+Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
+Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
+
+- Core 0.9.2.1 compatible. Changed hash algorithm for shared key derivation to `HKDF-HMAC-Sha256`.
+- Removed `senderPrivateKey` in `Persistent Delegation Request Transaction`. Instead, it uses an `ephemeral key pair` and the `EphemeralPublicKey` is now attached in the `PersistentDelegationMessage` payload.
+- Removed `salt` encryption and decryption functions which uses `HKDF-HMAC-Sha256` instead. This only affects the encrypted payload.
+- Added missing export in `Infrastructure` classes / interfaces.
+- Applied latest `catbuffer` builder codes for `ResolutionStatement`.
+- Updated `TransactionType` & `TransactionVersion` enum key name to match `catabuffer` schema definition.
+- Changed signature type for `Height` from `numeric string` to `UInt64` in `Block` & `Receipt` respostiories
+- Fixed a few ts lint issues.
+
 ## 09-Jan-2020
 
 **Milestone**: Fushicho.3

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
-### _Fushicho_ Network Compatibility (catapult-server@0.9.1.1)
+### _Fushicho_ Network Compatibility (catapult-server@0.9.2.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.1.1) version, **it is recommended to use this package's 0.16.3 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.2.1) version, **it is recommended to use this package's 0.16.4 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.16.3](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.3) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.16.4](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.4) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.3",
+  "version": "0.16.4",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
## 30-Jan-2020

**Milestone**: Fushicho.4(RC3)
 Versions  |   |
---|---|---
SDK Core| v0.16.4 | https://www.npmjs.com/package/nem2-sdk
Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client

- Core 0.9.2.1 compatible. Changed hash algorithm for shared key derivation to `HKDF-HMAC-Sha256`.
- Removed `senderPrivateKey` in `Persistent Delegation Request Transaction`. Instead, it uses an `ephemeral key pair` and the `EphemeralPublicKey` is now attached in the `PersistentDelegationMessage` payload.
- Removed `salt` encryption and decryption functions which uses `HKDF-HMAC-Sha256` instead. This only affects the encrypted payload.
- Added missing export in `Infrastructure` classes / interfaces.
- Applied latest `catbuffer` builder codes for `ResolutionStatement`.
- Updated `TransactionType` & `TransactionVersion` enum key name to match `catabuffer` schema definition.
- Changed signature type for `Height` from `numeric string` to `UInt64` in `Block` & `Receipt` respostiories
- Fixed a few ts lint issues.