### PR TITLE
v0.16.5 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ The changelog format is based on [Keep a Changelog](https://keepachangelog.com/e
 **Milestone**: Fushicho.4(RC3)
  Versions  |   |
 ---|---|---
+SDK Core| v0.16.5 | https://www.npmjs.com/package/nem2-sdk
+Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
+Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
+
+- Fixed circular reference issue after removed `InnerTransaction` class.
+
+## 30-Jan-2020
+
+**Milestone**: Fushicho.4(RC3)
+ Versions  |   |
+---|---|---
 SDK Core| v0.16.4 | https://www.npmjs.com/package/nem2-sdk
 Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
 Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
@@ -346,6 +357,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.16.5]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3
 [0.16.2]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.1...v0.16.2

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ with the NEM2 (a.k.a Catapult)
 
 ### _Fushicho_ Network Compatibility (catapult-server@0.9.2.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.2.1) version, **it is recommended to use this package's 0.16.4 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.2.1) version, **it is recommended to use this package's 0.16.5 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.16.4](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.4) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.16.5](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.5) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.4",
+  "version": "0.16.5",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",


### PR DESCRIPTION
## 30-Jan-2020

**Milestone**: Fushicho.4(RC3)
 Versions  |   |
---|---|---
SDK Core| v0.16.5 | https://www.npmjs.com/package/nem2-sdk
Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
Client Library | v0.7.20-beta.7  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client

- Fixed circular reference issue after removed `InnerTransaction` class.