### PR TITLE
v0.17.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,26 @@ All notable changes to this project will be documented in this file.
 
 The changelog format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 17-Feb-2020
+
+**Milestone**: Fushicho.4(RC3 0.9.3.1)
+ Versions  |   |
+---|---|---
+SDK Core| v0.17.0 | https://www.npmjs.com/package/nem2-sdk
+Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
+Client Library | v0.8.4  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client
+
+- **[BREAKING CHANGE]** Changed hashing algorithm to cope catapult-server changes. All Key derivation and signing are now using `SHA512`. Removed `SignSchema` so `NetworkType` is no longer bonded to the schema anymore (sha3 / keccak). This change will affect all existing keypairs / address (derived from public key) and  transaction signatures.
+- **[BREAKING CHANGE]** Added new `TransactionFilter` parameter to `AccountHttp` which is now support filtering with list of transaction type.
+- Added `GenerationHash` to the payload in `node/info` endpoint.
+- Added enum for block merkle path item positions (`left / right`) to replace previous number type value (`1 / 2`).
+- Added new `BlockService` for `Transaction` and `Receipt` block merkle proof auditing.
+- Added new node type `Dual` to the existing `RoleTypeEnum`.
+- Added new endpoint `node/health` in `NodeHttp`.
+- Moved `getStorageInfo` and `getServerInfo` from `DiagnosticHttp` to `NodeHttp` repository.
+- Improved e2e testing by using `async / await`.
+- General legacy code refactoring and cleanup.
+
 ## 30-Jan-2020
 
 **Milestone**: Fushicho.4(RC3)
@@ -357,6 +377,7 @@ Client Library | v0.7.20-alpha.6  | https://www.npmjs.com/package/nem2-sdk-opena
 **Milestone**: Alpaca
 
 - Initial code release.
+[0.17.0]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.5...v0.17.0
 [0.16.5]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.4...v0.16.5
 [0.16.4]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.3...v0.16.4
 [0.16.3]: https://github.com/nemtech/nem2-sdk-typescript-javascript/compare/v0.16.2...v0.16.3

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ with the NEM2 (a.k.a Catapult)
 
 ## Important Notes
 
-### _Fushicho_ Network Compatibility (catapult-server@0.9.2.1)
+### _Fushicho_ Network Compatibility (catapult-server@0.9.3.1)
 
-Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.2.1) version, **it is recommended to use this package's 0.16.5 version and upwards to use this package with Fushicho versioned networks**.
+Due to a network upgrade with [catapult-server@Fushicho](https://github.com/nemtech/catapult-server/releases/tag/v0.9.3.1) version, **it is recommended to use this package's 0.17.0 version and upwards to use this package with Fushicho versioned networks**.
 
-The upgrade to this package's [version v0.16.5](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.16.5) is mandatory for **fushicho compatibility**.
+The upgrade to this package's [version v0.17.0](https://github.com/nemtech/nem2-sdk-typescript-javascript/releases/tag/v0.17.0) is mandatory for **fushicho compatibility**.
 
 ### _Elephant_ Network Compatibility (catapult-server@0.7.0.1)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nem2-sdk",
-  "version": "0.16.5",
+  "version": "0.17.0",
   "description": "Reactive Nem2 sdk for typescript and javascript",
   "scripts": {
     "pretest": "npm run build",

--- a/src/service/service.ts
+++ b/src/service/service.ts
@@ -21,3 +21,5 @@ export * from './MetadataTransactionService';
 export * from './MosaicRestrictionTransactionService';
 export * from './TransactionService';
 export * from './BlockService';
+export * from './interfaces/IBlockService';
+export * from './interfaces/ITransactionService';


### PR DESCRIPTION
## 17-Feb-2020

**Milestone**: Fushicho.4(RC3 0.9.3.1)
 Versions  |   |
---|---|---
SDK Core| v0.17.0 | https://www.npmjs.com/package/nem2-sdk
Catbuffer Library| v0.0.11 | https://www.npmjs.com/package/catbuffer
Client Library | v0.8.4  | https://www.npmjs.com/package/nem2-sdk-openapi-typescript-node-client

- **[BREAKING CHANGE]** Changed hashing algorithm to cope catapult-server changes. All Key derivation and signing are now using `SHA512`. Removed `SignSchema` so `NetworkType` is no longer bonded to the schema anymore (sha3 / keccak). This change will affect all existing keypairs / address (derived from public key) and  transaction signatures.
- **[BREAKING CHANGE]** Added new `TransactionFilter` parameter to `AccountHttp` which is now support filtering with list of transaction type.
- Added `GenerationHash` to the payload in `node/info` endpoint.
- Added enum for block merkle path item positions (`left / right`) to replace previous number type value (`1 / 2`).
- Added new `BlockService` for `Transaction` and `Receipt` block merkle proof auditing.
- Added new node type `Dual` to the existing `RoleTypeEnum`.
- Added new endpoint `node/health` in `NodeHttp`.
- Moved `getStorageInfo` and `getServerInfo` from `DiagnosticHttp` to `NodeHttp` repository.
- Improved e2e testing by using `async / await`.
- General legacy code refactoring and cleanup.